### PR TITLE
Add error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,11 @@ set(BUILD_TESTS OFF)
 set(BUILD_CLI OFF)
 set(USE_HTTPS OFF)
 SET(USE_NTLMCLIENT OFF)
+set(EXPECTED_BUILD_PACKAGE OFF)
+set(BUILD_TESTING OFF)
 
 add_subdirectory(libgit2)
+add_subdirectory(expected)
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.
 # If you are developing for iOS or macOS you should consider setting an
@@ -39,7 +42,7 @@ set_target_properties(appgit-se2 PROPERTIES
 
 target_include_directories(appgit-se2 PRIVATE ${PROJECT_SOURCE_DIR}/libgit2/include)
 target_link_libraries(appgit-se2
-    PRIVATE Qt6::Quick Qt6::QuickControls2 libgit2package
+    PRIVATE Qt6::Quick Qt6::QuickControls2 libgit2package expected
 )
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ qt_add_qml_module(appgit-se2
     VERSION 1.0
     QML_FILES
         Main.qml
+        SOURCES error-handling.h error-handling.cpp
 )
 
 set(BUILD_TESTS OFF)

--- a/error-handling.cpp
+++ b/error-handling.cpp
@@ -1,0 +1,61 @@
+#include "error-handling.h"
+
+#include <sstream>
+
+std::string gitse2::explain_nested_error(const Error& e) {
+    std::stringstream ss;
+    unwind_nested(e, [&](const Error& ex) {
+        if (is_nested_error(ex))
+            ss << ex.fun_name << " ("<<ex.source<<":"<<ex.source_line<<")\n";
+        else if (ex.cb)
+            ss << ex.cb(ex);
+        else
+            ss << explain_generic(ex) << "\n";
+    });
+    return ss.str();
+}
+
+std::string gitse2::explain_generic(const Error& ex) {
+    std::stringstream ss;
+    ss << ex.fun_name << " ("<<ex.source<<":"<<ex.source_line<<") "<<code_to_string(ex.code);
+    return ss.str();
+}
+
+std::string gitse2::explain_invalid_parameter(const Error& e) {
+    std::stringstream ss;
+    ss << explain_generic(e) << "invalid input parameter `"<<std::any_cast<std::string>(e)<<"`\n";
+    return ss.str();
+}
+
+bool gitse2::is_nested_error(const Error& e) {
+    return e.cb == explain_nested_error;
+}
+
+namespace gitse2 {
+    template<>
+    const Error& get_nested<0>(const Error& e) {
+        return e;
+    }
+}
+
+std::string gitse2::code_to_string(ErrorCode ec) {
+    static const std::unordered_map<ErrorCode, std::string> error_map {
+        {ErrorCode::None, "No error"}
+    };
+
+    auto it = error_map.find(ec);
+    if (it != error_map.end())
+        return it->second;
+
+    return "";
+}
+std::string gitse2::explain_combined_error(const gitse2::Error& e) {
+    std::stringstream ss;
+
+    auto combined = std::any_cast<combined_error>(e.aux);
+    ss << explain_nested_error(combined.first);
+    ss << "\n at the same time:\n";
+    ss << explain_nested_error(combined.second);
+
+    return ss.str();
+}

--- a/error-handling.h
+++ b/error-handling.h
@@ -1,0 +1,79 @@
+#ifndef ERRORHANDLING_H
+#define ERRORHANDLING_H
+
+#include <any>
+#include <string>
+#include <tl/expected.hpp>
+
+namespace gitse2 {
+    enum class ErrorCode {
+        None,
+    };
+
+    using explain_aux_callback = std::string(*)(const struct Error&);
+
+    struct Error {
+        ErrorCode code {ErrorCode::None};
+        explain_aux_callback cb {nullptr};
+        std::string fun_name;
+        std::string source;
+        int source_line {0};
+        std::any aux;
+    };
+
+    template<typename T = void>
+    using Result = tl::expected<T, Error>;
+
+    using combined_error = std::pair<Error,Error>;
+
+    std::string explain_nested_error(const Error& e);
+    std::string explain_generic(const Error& e);
+    std::string code_to_string(ErrorCode ec);
+    std::string explain_invalid_parameter(const Error& e);
+    std::string explain_combined_error(const Error& e);
+
+    template <typename ME>
+    [[maybe_unused]] Error make_combined_error_(const Error& e, const ME& might_be_e, ErrorCode c, const char* func, const char* source, int line) {
+        if (!might_be_e)
+            return gitse2::Error{c,explain_combined_error,func,source,line,combined_error(e, might_be_e.error())};
+        return e;
+    }
+
+    template<typename F>
+    void unwind_nested(const Error& e, F && callback) {
+        const Error* e_it = &e;
+        while (e_it->cb == explain_nested_error) {
+            callback(*e_it);
+            e_it = &std::any_cast<const Error&>(e_it->aux);
+        }
+        callback(*e_it);
+    }
+
+    bool is_nested_error(const Error& e);
+
+    template <int N>
+    const Error& get_nested(const Error& e) {
+        return std::any_cast<const Error&>(get_nested<N-1>(e).aux);
+    }
+    template <>
+    const Error& get_nested<0>(const Error& e);
+}
+
+#define unexpected_error(code) tl::unexpected<gitse2::Error>({code, gitse2::explain_generic, __PRETTY_FUNCTION__, __FILE__, __LINE__})
+#define unexpected_explained(code, foo, bar) tl::unexpected<gitse2::Error>({code, foo, __PRETTY_FUNCTION__, __FILE__, __LINE__, bar})
+#define unexpected_sqlite_exception(code, bar) tl::unexpected<gitse2::Error>({code, gitse2::explain_sqlite_error, __PRETTY_FUNCTION__, __FILE__, __LINE__, bar})
+#define unexpected_nested(code, nested) tl::unexpected<gitse2::Error>({code, gitse2::explain_nested_error, __PRETTY_FUNCTION__, __FILE__, __LINE__, nested});
+#define unexpected_invalid_input_parameter(code, param_name) tl::unexpected<gitse2::Error>({code, gitse2::explain_invalid_parameter, __PRETTY_FUNCTION__, __FILE__, __LINE__, std::string(param_name)})
+#define unexpected_combined_error(code, nested1, nested2) tl::unexpected<gitse2::Error>({code, gitse2::explain_combined_error, __PRETTY_FUNCTION__, __FILE__, __LINE__, make_combined_error(nested1, nested2, code)});
+#define make_combined_error(e, might_e, c) gitse2::make_combined_error_(e, might_e, c, __PRETTY_FUNCTION__, __FILE__, __LINE__)
+#define make_nested_error(c, nested) gitse2::Error{c, gitse2::explain_nested_error, __PRETTY_FUNCTION__, __FILE__, __LINE__, nested}
+#define make_sqlite_error(c, code) gitse2::Error{c, gitse2::explain_sqlite_error, __PRETTY_FUNCTION__, __FILE__, __LINE__, code}
+
+
+class error_handling
+{
+public:
+    error_handling();
+};
+
+#endif // ERRORHANDLING_H


### PR DESCRIPTION
## 1. Involve expected library into project

This changeset modifies the `CMakeLists.txt` file in the project. It adds a new setting `EXPECTED_BUILD_PACKAGE` and `BUILD_TESTING` to `OFF`. Additionally, it includes the `expected` library into the project by adding a new subdirectory. The `target_link_libraries` now includes the `expected` library along with other dependencies.

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 22b80dc..128b370 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,11 @@ qt_add_qml_module(appgit-se2
 set(BUILD_CLI OFF)
 set(USE_HTTPS OFF)
 SET(USE_NTLMCLIENT OFF)
+set(EXPECTED_BUILD_PACKAGE OFF)
+set(BUILD_TESTING OFF)
 
 add_subdirectory(libgit2)
+add_subdirectory(expected)
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.
 # If you are developing for iOS or macOS you should consider setting an
@@ -39,7 +42,7 @@ set_target_properties(appgit-se2 PROPERTIES
 
 target_include_directories(appgit-se2 PRIVATE ${PROJECT_SOURCE_DIR}/libgit2/include)
 target_link_libraries(appgit-se2
-    PRIVATE Qt6::Quick Qt6::QuickControls2 libgit2package
+    PRIVATE Qt6::Quick Qt6::QuickControls2 libgit2package expected
 )
 
 include(GNUInstallDirs)

```

## 2. Add error hadnling classes

The changeset includes the addition of error handling classes to the project. 

1. In the `CMakeLists.txt` file, the `error-handling.h` and `error-handling.cpp` files are added as sources for the `appgit-se2` QML module.

2. A new file `error-handling.cpp` is created, which defines functions like `explain_nested_error`, `explain_generic`, `explain_invalid_parameter`, `is_nested_error`, `code_to_string`, and `explain_combined_error` for handling errors.

3. Another new file `error-handling.h` is added, which includes declarations for error handling structures like `Error`, `Result`, `combined_error`, and functions like `explain_nested_error`, `explain_generic`, `code_to_string`, `explain_invalid_parameter`, `explain_combined_error`, `unwind_nested`, `is_nested_error`, `get_nested`, and macros for generating unexpected errors and combined errors.

Overall, these changes introduce a robust error handling mechanism to the project.

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 779a734..128b370 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ qt_add_qml_module(appgit-se2
     VERSION 1.0
     QML_FILES
         Main.qml
+        SOURCES error-handling.h error-handling.cpp
 )
 
 set(BUILD_TESTS OFF)
diff --git a/error-handling.cpp b/error-handling.cpp
new file mode 100644
index 0000000..5b67772
--- /dev/null
+++ b/error-handling.cpp
@@ -0,0 +1,61 @@
+#include "error-handling.h"
+
+#include <sstream>
+
+std::string gitse2::explain_nested_error(const Error& e) {
+    std::stringstream ss;
+    unwind_nested(e, [&](const Error& ex) {
+        if (is_nested_error(ex))
+            ss << ex.fun_name << " ("<<ex.source<<":"<<ex.source_line<<")\n";
+        else if (ex.cb)
+            ss << ex.cb(ex);
+        else
+            ss << explain_generic(ex) << "\n";
+    });
+    return ss.str();
+}
+
+std::string gitse2::explain_generic(const Error& ex) {
+    std::stringstream ss;
+    ss << ex.fun_name << " ("<<ex.source<<":"<<ex.source_line<<") "<<code_to_string(ex.code);
+    return ss.str();
+}
+
+std::string gitse2::explain_invalid_parameter(const Error& e) {
+    std::stringstream ss;
+    ss << explain_generic(e) << "invalid input parameter `"<<std::any_cast<std::string>(e)<<"`\n";
+    return ss.str();
+}
+
+bool gitse2::is_nested_error(const Error& e) {
+    return e.cb == explain_nested_error;
+}
+
+namespace gitse2 {
+    template<>
+    const Error& get_nested<0>(const Error& e) {
+        return e;
+    }
+}
+
+std::string gitse2::code_to_string(ErrorCode ec) {
+    static const std::unordered_map<ErrorCode, std::string> error_map {
+        {ErrorCode::None, "No error"}
+    };
+
+    auto it = error_map.find(ec);
+    if (it != error_map.end())
+        return it->second;
+
+    return "";
+}
+std::string gitse2::explain_combined_error(const gitse2::Error& e) {
+    std::stringstream ss;
+
+    auto combined = std::any_cast<combined_error>(e.aux);
+    ss << explain_nested_error(combined.first);
+    ss << "\n at the same time:\n";
+    ss << explain_nested_error(combined.second);
+
+    return ss.str();
+}
diff --git a/error-handling.h b/error-handling.h
new file mode 100644
index 0000000..98ec901
--- /dev/null
+++ b/error-handling.h
@@ -0,0 +1,79 @@
+#ifndef ERRORHANDLING_H
+#define ERRORHANDLING_H
+
+#include <any>
+#include <string>
+#include <tl/expected.hpp>
+
+namespace gitse2 {
+    enum class ErrorCode {
+        None,
+    };
+
+    using explain_aux_callback = std::string(*)(const struct Error&);
+
+    struct Error {
+        ErrorCode code {ErrorCode::None};
+        explain_aux_callback cb {nullptr};
+        std::string fun_name;
+        std::string source;
+        int source_line {0};
+        std::any aux;
+    };
+
+    template<typename T = void>
+    using Result = tl::expected<T, Error>;
+
+    using combined_error = std::pair<Error,Error>;
+
+    std::string explain_nested_error(const Error& e);
+    std::string explain_generic(const Error& e);
+    std::string code_to_string(ErrorCode ec);
+    std::string explain_invalid_parameter(const Error& e);
+    std::string explain_combined_error(const Error& e);
+
+    template <typename ME>
+    [[maybe_unused]] Error make_combined_error_(const Error& e, const ME& might_be_e, ErrorCode c, const char* func, const char* source, int line) {
+        if (!might_be_e)
+            return gitse2::Error{c,explain_combined_error,func,source,line,combined_error(e, might_be_e.error())};
+        return e;
+    }
+
+    template<typename F>
+    void unwind_nested(const Error& e, F && callback) {
+        const Error* e_it = &e;
+        while (e_it->cb == explain_nested_error) {
+            callback(*e_it);
+            e_it = &std::any_cast<const Error&>(e_it->aux);
+        }
+        callback(*e_it);
+    }
+
+    bool is_nested_error(const Error& e);
+
+    template <int N>
+    const Error& get_nested(const Error& e) {
+        return std::any_cast<const Error&>(get_nested<N-1>(e).aux);
+    }
+    template <>
+    const Error& get_nested<0>(const Error& e);
+}
+
+#define unexpected_error(code) tl::unexpected<gitse2::Error>({code, gitse2::explain_generic, __PRETTY_FUNCTION__, __FILE__, __LINE__})
+#define unexpected_explained(code, foo, bar) tl::unexpected<gitse2::Error>({code, foo, __PRETTY_FUNCTION__, __FILE__, __LINE__, bar})
+#define unexpected_sqlite_exception(code, bar) tl::unexpected<gitse2::Error>({code, gitse2::explain_sqlite_error, __PRETTY_FUNCTION__, __FILE__, __LINE__, bar})
+#define unexpected_nested(code, nested) tl::unexpected<gitse2::Error>({code, gitse2::explain_nested_error, __PRETTY_FUNCTION__, __FILE__, __LINE__, nested});
+#define unexpected_invalid_input_parameter(code, param_name) tl::unexpected<gitse2::Error>({code, gitse2::explain_invalid_parameter, __PRETTY_FUNCTION__, __FILE__, __LINE__, std::string(param_name)})
+#define unexpected_combined_error(code, nested1, nested2) tl::unexpected<gitse2::Error>({code, gitse2::explain_combined_error, __PRETTY_FUNCTION__, __FILE__, __LINE__, make_combined_error(nested1, nested2, code)});
+#define make_combined_error(e, might_e, c) gitse2::make_combined_error_(e, might_e, c, __PRETTY_FUNCTION__, __FILE__, __LINE__)
+#define make_nested_error(c, nested) gitse2::Error{c, gitse2::explain_nested_error, __PRETTY_FUNCTION__, __FILE__, __LINE__, nested}
+#define make_sqlite_error(c, code) gitse2::Error{c, gitse2::explain_sqlite_error, __PRETTY_FUNCTION__, __FILE__, __LINE__, code}
+
+
+class error_handling
+{
+public:
+    error_handling();
+};
+
+#endif // ERRORHANDLING_H

```
