### PR TITLE
Squash it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ qt_add_qml_module(appgit-se2
     QML_FILES
         Main.qml
         SOURCES error-handling.h error-handling.cpp program_options.h program_options.cpp
-        SOURCES repository.h repository.cpp
+        SOURCES repository.h repository.cpp git-etcetera.h
 )
 
 set(BUILD_TESTS OFF)

--- a/error-handling.cpp
+++ b/error-handling.cpp
@@ -6,7 +6,7 @@ std::string gitse2::explain_nested_error(const Error& e) {
     std::stringstream ss;
     unwind_nested(e, [&](const Error& ex) {
         if (is_nested_error(ex))
-            ss << ex.fun_name << " ("<<ex.source<<":"<<ex.source_line<<")\n";
+            ss << ex.fun_name << " (file://"<<ex.source<<":"<<ex.source_line<<")\n";
         else if (ex.cb)
             ss << ex.cb(ex);
         else
@@ -17,7 +17,7 @@ std::string gitse2::explain_nested_error(const Error& e) {
 
 std::string gitse2::explain_generic(const Error& ex) {
     std::stringstream ss;
-    ss << ex.fun_name << " ("<<ex.source<<":"<<ex.source_line<<") "<<code_to_string(ex.code);
+    ss << ex.fun_name << " (file://"<<ex.source<<":"<<ex.source_line<<") "<<code_to_string(ex.code);
     return ss.str();
 }
 

--- a/error-handling.h
+++ b/error-handling.h
@@ -10,6 +10,7 @@ namespace gitse2 {
         None,
         FirstCommitOmittedError,
         GitRepositoryOpenError,
+        GitGenericError,
     };
 
     using explain_aux_callback = std::string(*)(const struct Error&);

--- a/git-etcetera.h
+++ b/git-etcetera.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <git2.h>
+#include <memory>
+
+struct git_annotated_commit_deleter {
+    void operator()(git_annotated_commit* p) {
+        git_annotated_commit_free(p);
+    }
+};
+
+struct git_commit_deleter {
+    void operator()(git_commit* p) {
+        git_commit_free(p);
+    }
+};
+
+struct git_tree_deleter {
+    void operator()(git_tree* p) {
+        git_tree_free(p);
+    }
+};
+
+struct git_diff_deleter {
+    void operator()(git_diff* p) {
+        git_diff_free(p);
+    }
+};
+
+struct git_index_deleter {
+    void operator()(git_index* p) {
+        git_index_free(p);
+    }
+};
+
+struct git_signature_deleter {
+    void operator()(git_signature* p) {
+        git_signature_free(p);
+    }
+};
+
+struct git_reference_deleter {
+    void operator()(git_reference* p) {
+        git_reference_free(p);
+    }
+};
+
+struct git_repository_deleter {
+    void operator()(git_repository* p) {
+        git_repository_free(p);
+    }
+};
+
+using git_annotated_commit_ptr = std::unique_ptr<git_annotated_commit, git_annotated_commit_deleter>;
+using git_commit_ptr = std::unique_ptr<git_commit, git_commit_deleter>;
+using git_tree_ptr = std::unique_ptr<git_tree, git_tree_deleter>;
+using git_diff_ptr = std::unique_ptr<git_diff, git_diff_deleter>;
+using git_index_ptr = std::unique_ptr<git_index, git_index_deleter>;
+using git_signature_ptr = std::unique_ptr<git_signature, git_signature_deleter>;
+using git_reference_ptr = std::unique_ptr<git_reference, git_reference_deleter>;
+using git_repository_ptr = std::unique_ptr<git_repository, git_repository_deleter>;

--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,12 @@ int main(int argc, char *argv[])
         return 2;
     }
 
+    auto rval = repo.value()->squash(options.value().first_commit());
+    if (!rval) {
+        qCritical().noquote() << gitse2::explain_nested_error(rval.error());
+        return 3;
+    }
+
     QQmlApplicationEngine engine;
     const QUrl url(QStringLiteral("qrc:/git-se2/Main.qml"));
     QObject::connect(

--- a/program_options.cpp
+++ b/program_options.cpp
@@ -23,6 +23,10 @@ gitse2::Result<gitse2::ProgramOptions> gitse2::ProgramOptions::parse_program_opt
     if (posArgs.empty())
         return unexpected_explained(ErrorCode::FirstCommitOmittedError, explain_command_options_error, parser.helpText());
 
-    opts.m_first_commit = posArgs.at(0);
+    opts.m_first_commit = posArgs.at(0).toStdString();
     return opts;
+}
+
+const std::string &gitse2::ProgramOptions::first_commit() {
+    return m_first_commit;
 }

--- a/program_options.h
+++ b/program_options.h
@@ -9,6 +9,7 @@ namespace gitse2 {
     {
         public:
             static Result<ProgramOptions> parse_program_options(const QCoreApplication& app);
+            const std::string& first_commit();
         private:
             ProgramOptions() = default;
 

--- a/program_options.h
+++ b/program_options.h
@@ -12,7 +12,7 @@ namespace gitse2 {
         private:
             ProgramOptions() = default;
 
-            QString m_first_commit;
+            std::string m_first_commit;
     };
 }
 

--- a/repository.cpp
+++ b/repository.cpp
@@ -146,7 +146,6 @@ Result<> Repository::squash(const std::string& first_commit) {
     return {};
 }
 
-Repository::~Repository()
 Result<git_annotated_commit_ptr> Repository::resolve_commit(const std::string &commit) {
     int err = 0;
     git_reference *ref = NULL;
@@ -174,7 +173,6 @@ Result<git_annotated_commit_ptr> Repository::resolve_commit(const std::string &c
 
 Result<> Repository::resolve_commit(const std::string &commit, git_annotated_commit_ptr &gac, git_commit_ptr &gc)
 {
-    git_repository_free(m_repo);
     auto rval = resolve_commit(commit);
     if (!rval)
         return unexpected_nested(ErrorCode::GitGenericError, rval.error());

--- a/repository.cpp
+++ b/repository.cpp
@@ -1,6 +1,8 @@
 #include "repository.h"
+#include "qdebug.h"
 #include <qglobal.h>
 #include <sstream>
+#include <fmt/format.h>
 
 using namespace gitse2;
 
@@ -48,6 +50,18 @@ Result<RepositoryRef> Repository::open()
     int error = git_repository_open_ext(&out_ref->m_repo, out_ref->m_repo_path.c_str(), 0, NULL);
     if (error != 0 || !out_ref->m_repo)
         return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_open_fail, error);
+
+template <> class fmt::formatter<git_commit_ptr> {
+public:
+    constexpr auto parse (format_parse_context& ctx) { return ctx.begin(); }
+    template <typename Context>
+    constexpr auto format (const git_commit_ptr& commit, Context& ctx) const {
+        char oid_str[GIT_OID_HEXSZ + 1] = {};
+        auto oid = git_commit_id(commit.get());
+        git_oid_tostr(oid_str, sizeof(oid_str), oid);
+        return format_to(ctx.out(), "{}", oid_str);
+    }
+};
 
     return {};
 }

--- a/repository.cpp
+++ b/repository.cpp
@@ -42,6 +42,21 @@ static std::string explain_repository_open_fail(const Error& e) {
     return ss.str();
 }
 
+static std::string explain_repository_fail(const Error& e) {
+    const git_error *last_error = giterr_last();
+
+    std::stringstream ss;
+
+    ss << explain_generic(e);
+    ss << "libgit2 error = " << std::any_cast<int>(e.aux);
+    if (last_error) {
+        ss << ", last_error: "<<last_error->message<<"\n";
+    }
+
+    return ss.str();
+}
+
+
 Result<RepositoryRef> Repository::open()
 {
     _initializer->init();

--- a/repository.cpp
+++ b/repository.cpp
@@ -47,9 +47,15 @@ Result<RepositoryRef> Repository::open()
     _initializer->init();
     RepositoryRef out_ref(new Repository());
 
-    int error = git_repository_open_ext(&out_ref->m_repo, out_ref->m_repo_path.c_str(), 0, NULL);
-    if (error != 0 || !out_ref->m_repo)
+    git_repository* repo = nullptr;
+    int error = git_repository_open_ext(&repo, out_ref->m_repo_path.c_str(), 0, NULL);
+    if (error != 0 || !repo)
         return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_open_fail, error);
+
+    out_ref->m_repo.reset(repo);
+
+    return out_ref;
+}
 
 template <> class fmt::formatter<git_commit_ptr> {
 public:

--- a/repository.cpp
+++ b/repository.cpp
@@ -153,3 +153,15 @@ Result<git_commit_ptr> Repository::checkout_commit(const std::string &commit) {
 
     return target_commit;
 }
+
+Result<> Repository::create_branch(const std::string &branch, const git_commit_ptr& commit) {
+    // will be creating branch on HEAD
+
+    git_reference* ref = nullptr; // free reference???
+    int err = git_branch_create(&ref, m_repo.get(), branch.c_str(), commit.get(), 1);
+    if (err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    git_reference_ptr ref_ptr(ref);
+    return {};
+}

--- a/repository.h
+++ b/repository.h
@@ -28,6 +28,7 @@ namespace gitse2 {
             [[nodiscard]] Result<> resolve_commit(const std::string& commit, git_annotated_commit_ptr& gac, git_commit_ptr& gc);
             [[nodiscard]] Result<git_commit_ptr> checkout_commit(const std::string& commit);
             [[nodiscard]] Result<> create_branch(const std::string& branch, const git_commit_ptr& commit);
+            [[nodiscard]] Result<> apply_diff(const git_commit_ptr& commit1, const git_commit_ptr& commit2);
     };
 }
 

--- a/repository.h
+++ b/repository.h
@@ -17,7 +17,6 @@ namespace gitse2 {
             Q_DISABLE_COPY_MOVE(Repository)
 
             static Result<RepositoryRef> open();
-            ~Repository();
             [[nodiscard]] Result<> squash(const std::string& first_commit);
         private:
             Repository() = default;

--- a/repository.h
+++ b/repository.h
@@ -23,6 +23,7 @@ namespace gitse2 {
 
             std::string m_repo_path {"."};
             git_repository_ptr m_repo;
+            [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);
     };
 }
 

--- a/repository.h
+++ b/repository.h
@@ -23,8 +23,10 @@ namespace gitse2 {
 
             std::string m_repo_path {"."};
             git_repository_ptr m_repo;
+
             [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);
             [[nodiscard]] Result<> resolve_commit(const std::string& commit, git_annotated_commit_ptr& gac, git_commit_ptr& gc);
+            [[nodiscard]] Result<git_commit_ptr> checkout_commit(const std::string& commit);
     };
 }
 

--- a/repository.h
+++ b/repository.h
@@ -16,8 +16,9 @@ namespace gitse2 {
         public:
             Q_DISABLE_COPY_MOVE(Repository)
 
-            static Result<RepositoryRef> open();
+            [[nodiscard]] static Result<RepositoryRef> open();
             [[nodiscard]] Result<> squash(const std::string& first_commit);
+
         private:
             Repository() = default;
 

--- a/repository.h
+++ b/repository.h
@@ -18,6 +18,7 @@ namespace gitse2 {
 
             static Result<RepositoryRef> open();
             ~Repository();
+            [[nodiscard]] Result<> squash(const std::string& first_commit);
         private:
             Repository() = default;
 

--- a/repository.h
+++ b/repository.h
@@ -5,6 +5,7 @@
 #include "error-handling.h"
 #include <git2.h>
 #include <QtCore/qglobal.h>
+#include "git-etcetera.h"
 
 namespace gitse2 {
 
@@ -21,7 +22,7 @@ namespace gitse2 {
             Repository() = default;
 
             std::string m_repo_path {"."};
-            git_repository* m_repo;
+            git_repository_ptr m_repo;
     };
 }
 

--- a/repository.h
+++ b/repository.h
@@ -27,6 +27,7 @@ namespace gitse2 {
             [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);
             [[nodiscard]] Result<> resolve_commit(const std::string& commit, git_annotated_commit_ptr& gac, git_commit_ptr& gc);
             [[nodiscard]] Result<git_commit_ptr> checkout_commit(const std::string& commit);
+            [[nodiscard]] Result<> create_branch(const std::string& branch, const git_commit_ptr& commit);
     };
 }
 

--- a/repository.h
+++ b/repository.h
@@ -24,6 +24,7 @@ namespace gitse2 {
             std::string m_repo_path {"."};
             git_repository_ptr m_repo;
             [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);
+            [[nodiscard]] Result<> resolve_commit(const std::string& commit, git_annotated_commit_ptr& gac, git_commit_ptr& gc);
     };
 }
 


### PR DESCRIPTION
## 1. Introduce a generic error code for libgit2

This changeset introduces a new generic error code `GitGenericError` to the `error-handling.h` file in the `libgit2` library. This error code can be used to represent generic errors within the library.

```diff
diff --git a/error-handling.h b/error-handling.h
index 22a65d1..e29c596 100644
--- a/error-handling.h
+++ b/error-handling.h
@@ -10,6 +10,7 @@ namespace gitse2 {
         None,
         FirstCommitOmittedError,
         GitRepositoryOpenError,
+        GitGenericError,
     };
 
     using explain_aux_callback = std::string(*)(const struct Error&);

```

## 2. Qt output window can create links with file:// prefix

The changeset modifies the `error-handling.cpp` file in the project. It updates the `explain_nested_error` and `explain_generic` functions to include a `file://` prefix when creating links to files. This means that when generating error messages, the functions will now format the source file location with a clickable link using the `file://` prefix.

```diff
diff --git a/error-handling.cpp b/error-handling.cpp
index 5b67772..2b1f4fd 100644
--- a/error-handling.cpp
+++ b/error-handling.cpp
@@ -6,7 +6,7 @@ std::string gitse2::explain_nested_error(const Error& e) {
     std::stringstream ss;
     unwind_nested(e, [&](const Error& ex) {
         if (is_nested_error(ex))
-            ss << ex.fun_name << " ("<<ex.source<<":"<<ex.source_line<<")\n";
+            ss << ex.fun_name << " (file://"<<ex.source<<":"<<ex.source_line<<")\n";
         else if (ex.cb)
             ss << ex.cb(ex);
         else
@@ -17,7 +17,7 @@ std::string gitse2::explain_nested_error(const Error& e) {
 
 std::string gitse2::explain_generic(const Error& ex) {
     std::stringstream ss;
-    ss << ex.fun_name << " ("<<ex.source<<":"<<ex.source_line<<") "<<code_to_string(ex.code);
+    ss << ex.fun_name << " (file://"<<ex.source<<":"<<ex.source_line<<") "<<code_to_string(ex.code);
     return ss.str();
 }
 

```

## 3. Introduce smart pointers for libgit2 structs

The changeset introduces smart pointers for libgit2 structs by adding a new header file `git-etcetera.h`. This header file defines custom deleter structs for various libgit2 structs like `git_annotated_commit`, `git_commit`, `git_tree`, `git_diff`, `git_index`, `git_signature`, `git_reference`, and `git_repository`. These custom deleter structs ensure proper cleanup of the corresponding libgit2 structs when the smart pointers go out of scope. Additionally, the changeset defines unique pointer aliases for each libgit2 struct type, such as `git_annotated_commit_ptr`, `git_commit_ptr`, `git_tree_ptr`, `git_diff_ptr`, `git_index_ptr`, `git_signature_ptr`, `git_reference_ptr`, and `git_repository_ptr`, using the defined custom deleter structs. This implementation helps manage memory and resources more efficiently when working with libgit2 structs in the codebase.

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index c575742..b4ee5ed 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ qt_add_qml_module(appgit-se2
     QML_FILES
         Main.qml
         SOURCES error-handling.h error-handling.cpp program_options.h program_options.cpp
-        SOURCES repository.h repository.cpp
+        SOURCES repository.h repository.cpp git-etcetera.h
 )
 
 set(BUILD_TESTS OFF)
diff --git a/git-etcetera.h b/git-etcetera.h
new file mode 100644
index 0000000..e0a35ee
--- /dev/null
+++ b/git-etcetera.h
@@ -0,0 +1,61 @@
+#pragma once
+
+#include <git2.h>
+#include <memory>
+
+struct git_annotated_commit_deleter {
+    void operator()(git_annotated_commit* p) {
+        git_annotated_commit_free(p);
+    }
+};
+
+struct git_commit_deleter {
+    void operator()(git_commit* p) {
+        git_commit_free(p);
+    }
+};
+
+struct git_tree_deleter {
+    void operator()(git_tree* p) {
+        git_tree_free(p);
+    }
+};
+
+struct git_diff_deleter {
+    void operator()(git_diff* p) {
+        git_diff_free(p);
+    }
+};
+
+struct git_index_deleter {
+    void operator()(git_index* p) {
+        git_index_free(p);
+    }
+};
+
+struct git_signature_deleter {
+    void operator()(git_signature* p) {
+        git_signature_free(p);
+    }
+};
+
+struct git_reference_deleter {
+    void operator()(git_reference* p) {
+        git_reference_free(p);
+    }
+};
+
+struct git_repository_deleter {
+    void operator()(git_repository* p) {
+        git_repository_free(p);
+    }
+};
+
+using git_annotated_commit_ptr = std::unique_ptr<git_annotated_commit, git_annotated_commit_deleter>;
+using git_commit_ptr = std::unique_ptr<git_commit, git_commit_deleter>;
+using git_tree_ptr = std::unique_ptr<git_tree, git_tree_deleter>;
+using git_diff_ptr = std::unique_ptr<git_diff, git_diff_deleter>;
+using git_index_ptr = std::unique_ptr<git_index, git_index_deleter>;
+using git_signature_ptr = std::unique_ptr<git_signature, git_signature_deleter>;
+using git_reference_ptr = std::unique_ptr<git_reference, git_reference_deleter>;
+using git_repository_ptr = std::unique_ptr<git_repository, git_repository_deleter>;

```

## 4. Change the type of m_first_commit

Change the type of `m_first_commit` from `QString` to `std::string` in the `ProgramOptions` class in the `program_options.h` file.

```diff
diff --git a/program_options.h b/program_options.h
index 672460d..9678beb 100644
--- a/program_options.h
+++ b/program_options.h
@@ -12,7 +12,7 @@ namespace gitse2 {
         private:
             ProgramOptions() = default;
 
-            QString m_first_commit;
+            std::string m_first_commit;
     };
 }
 

```

## 5. Add a getter for first commit command arg value

The changeset includes modifications in two files: `program_options.cpp` and `program_options.h`. 

In `program_options.cpp`, a getter function `first_commit()` has been added to the `gitse2::ProgramOptions` class. This function returns the `m_first_commit` member variable as a `const std::string&`. Previously, the `m_first_commit` member variable was being set directly from `posArgs.at(0)`, but now it is being set after converting `posArgs.at(0)` to a `std::string` using `toStdString()`.

In `program_options.h`, the declaration of the `first_commit()` getter function has been added to the `gitse2::ProgramOptions` class.

These changes allow external code to access the value of the `m_first_commit` member variable in a read-only manner.

```diff
diff --git a/program_options.cpp b/program_options.cpp
index 2ff992d..1eda76e 100644
--- a/program_options.cpp
+++ b/program_options.cpp
@@ -23,6 +23,10 @@ gitse2::Result<gitse2::ProgramOptions> gitse2::ProgramOptions::parse_program_opt
     if (posArgs.empty())
         return unexpected_explained(ErrorCode::FirstCommitOmittedError, explain_command_options_error, parser.helpText());
 
-    opts.m_first_commit = posArgs.at(0);
+    opts.m_first_commit = posArgs.at(0).toStdString();
     return opts;
 }
+
+const std::string &gitse2::ProgramOptions::first_commit() {
+    return m_first_commit;
+}
diff --git a/program_options.h b/program_options.h
index ab6dc00..9678beb 100644
--- a/program_options.h
+++ b/program_options.h
@@ -9,6 +9,7 @@ namespace gitse2 {
     {
         public:
             static Result<ProgramOptions> parse_program_options(const QCoreApplication& app);
+            const std::string& first_commit();
         private:
             ProgramOptions() = default;
 

```

## 6. Add libfmt formatter for git_commit_ptr

The changeset adds a new formatter for the `git_commit_ptr` type using the `libfmt` library. It includes the necessary header file for `fmt/format.h` and defines a new template class `formatter` specialized for `git_commit_ptr`. The `format` method in the class converts the commit ID to a string and returns it. This allows for formatting `git_commit_ptr` objects using the `libfmt` library in the `repository.cpp` file.

```diff
diff --git a/repository.cpp b/repository.cpp
index 76b0538..03ca545 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -1,6 +1,8 @@ 
 #include "repository.h"
+#include "qdebug.h"
 #include <qglobal.h>
 #include <sstream>
+#include <fmt/format.h>
 
 using namespace gitse2;
 
@@ -49,10 +51,22 @@ static std::string explain_repository_open_fail(const Error& e) {
     if (error != 0 || !out_ref->m_repo)
         return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_open_fail, error);
 
+template <> class fmt::formatter<git_commit_ptr> {
+public:
+    constexpr auto parse (format_parse_context& ctx) { return ctx.begin(); }
+    template <typename Context>
+    constexpr auto format (const git_commit_ptr& commit, Context& ctx) const {
+        char oid_str[GIT_OID_HEXSZ + 1] = {};
+        auto oid = git_commit_id(commit.get());
+        git_oid_tostr(oid_str, sizeof(oid_str), oid);
+        return format_to(ctx.out(), "{}", oid_str);
+    }
+};
+
     return {};
 }
 
 Repository::~Repository()
 {
     git_repository_free(m_repo);
 }

```

## 7. Use smart pointer for git_repository

The changeset introduces the usage of a smart pointer for `git_repository` in the `repository.cpp` and `repository.h` files. In `repository.cpp`, the patch replaces the direct usage of `git_repository*` with a smart pointer `git_repository_ptr`, and updates the code accordingly to use the smart pointer. This change ensures that memory management for `git_repository` is handled automatically by the smart pointer, avoiding potential memory leaks.

In `repository.h`, the patch includes the necessary header file `"git-etcetera.h"` to support the smart pointer `git_repository_ptr`. Additionally, it updates the `Repository` class to use `git_repository_ptr` instead of a raw pointer `git_repository*`, providing better memory management and reducing the risk of memory-related issues.

```diff
diff --git a/repository.cpp b/repository.cpp
index 680fc12..03ca545 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -47,10 +47,16 @@ static std::string explain_repository_open_fail(const Error& e) {
     _initializer->init();
     RepositoryRef out_ref(new Repository());
 
-    int error = git_repository_open_ext(&out_ref->m_repo, out_ref->m_repo_path.c_str(), 0, NULL);
-    if (error != 0 || !out_ref->m_repo)
+    git_repository* repo = nullptr;
+    int error = git_repository_open_ext(&repo, out_ref->m_repo_path.c_str(), 0, NULL);
+    if (error != 0 || !repo)
         return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_open_fail, error);
 
+    out_ref->m_repo.reset(repo);
+
+    return out_ref;
+}
+
 template <> class fmt::formatter<git_commit_ptr> {
 public:
     constexpr auto parse (format_parse_context& ctx) { return ctx.begin(); }
diff --git a/repository.h b/repository.h
index fa08f6f..7c142ac 100644
--- a/repository.h
+++ b/repository.h
@@ -5,6 +5,7 @@ 
 #include "error-handling.h"
 #include <git2.h>
 #include <QtCore/qglobal.h>
+#include "git-etcetera.h"
 
 namespace gitse2 {
 
@@ -21,7 +22,7 @@ namespace gitse2 {
             Repository() = default;
 
             std::string m_repo_path {"."};
-            git_repository* m_repo;
+            git_repository_ptr m_repo;
     };
 }
 

```

## 8. Introduce `resolve_commit`: returns annotated commit by hash

This changeset introduces a new method `resolve_commit` in the `Repository` class in both `repository.cpp` and `repository.h` files. The `resolve_commit` method takes a commit hash as input and returns an annotated commit pointer. 

In the `repository.cpp` file, the `resolve_commit` method first tries to resolve the commit using a reference and then falls back to resolving it using the commit hash directly if the reference resolution fails. If the resolution is successful, it returns the annotated commit pointer. If any error occurs during the resolution process, it returns an error code.

In the `repository.h` file, the `resolve_commit` method is declared as a `[[nodiscard]]` method, indicating that the return value should be checked by the caller.

```diff
diff --git a/repository.cpp b/repository.cpp
index bc9569a..03ca545 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -73,6 +73,30 @@ public:
 }
 
 Repository::~Repository()
+Result<git_annotated_commit_ptr> Repository::resolve_commit(const std::string &commit) {
+    int err = 0;
+    git_reference *ref = NULL;
+    git_annotated_commit* target = nullptr;
+
+    err = git_reference_dwim(&ref, m_repo.get(), commit.c_str());
+    if (err == GIT_OK) {
+        git_annotated_commit_from_ref(&target, m_repo.get(), ref);
+        git_reference_free(ref);
+        return git_annotated_commit_ptr(target);
+    }
+
+    git_object *obj;
+    err = git_revparse_single(&obj, m_repo.get(), commit.c_str());
+    if (err == GIT_OK) {
+        err = git_annotated_commit_lookup(&target, m_repo.get(), git_object_id(obj));
+        git_object_free(obj);
+    }
+
+    if (err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    return git_annotated_commit_ptr(target);
+}
 {
     git_repository_free(m_repo);
 }
diff --git a/repository.h b/repository.h
index 4741250..7c142ac 100644
--- a/repository.h
+++ b/repository.h
@@ -23,6 +23,7 @@ namespace gitse2 {
 
             std::string m_repo_path {"."};
             git_repository_ptr m_repo;
+            [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);
     };
 }
 

```

## 9. Introduce `resolve_commit` overload which return git_commit_ptr

This changeset introduces a new overload for the `resolve_commit` function in both `repository.cpp` and `repository.h` files. The new overload now returns a `Result` containing a `git_annotated_commit_ptr` and takes two additional parameters by reference: `git_annotated_commit_ptr& gac` and `git_commit_ptr& gc`. 

In the implementation in `repository.cpp`, after freeing the repository, it calls the existing `resolve_commit` function to get the annotated commit pointer. If successful, it moves the value to `gac`. Then, it looks up the commit using the obtained annotated commit ID and sets the result to `gc`. Finally, it returns an empty `Result` object.

```diff
diff --git a/repository.cpp b/repository.cpp
index d85efc8..03ca545 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -97,6 +97,22 @@ Result<git_annotated_commit_ptr> Repository::resolve_commit(const std::string &c
 
     return git_annotated_commit_ptr(target);
 }
+
+Result<> Repository::resolve_commit(const std::string &commit, git_annotated_commit_ptr &gac, git_commit_ptr &gc)
 {
     git_repository_free(m_repo);
+    auto rval = resolve_commit(commit);
+    if (!rval)
+        return unexpected_nested(ErrorCode::GitGenericError, rval.error());
+
+    gac = std::move(rval.value());
+
+    git_commit *target_commit = nullptr;
+    int err = git_commit_lookup(&target_commit, m_repo.get(), git_annotated_commit_id(gac.get()));
+    if (err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    gc.reset(target_commit);
+
+    return {};
 }
diff --git a/repository.h b/repository.h
index 109f47b..7c142ac 100644
--- a/repository.h
+++ b/repository.h
@@ -24,6 +24,7 @@ namespace gitse2 {
             std::string m_repo_path {"."};
             git_repository_ptr m_repo;
             [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);
+            [[nodiscard]] Result<> resolve_commit(const std::string& commit, git_annotated_commit_ptr& gac, git_commit_ptr& gc);
     };
 }
 

```

## 10. Introduce git checkout functionality

This changeset introduces a new functionality to the repository class in the codebase. It adds a new method `checkout_commit` that allows checking out a specific commit in the Git repository. 

The `checkout_commit` method takes a commit hash as a parameter, resolves the commit, sets up checkout options for safe checkout, performs the checkout operation, and then sets the repository's HEAD to the checked-out commit. If any errors occur during the process, appropriate error handling is implemented to return detailed error information.

Additionally, the header file `repository.h` is updated to include the declaration of the new `checkout_commit` method in the `gitse2` namespace.

```diff
diff --git a/repository.cpp b/repository.cpp
index dbb5263..03ca545 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -116,3 +116,25 @@ Result<> Repository::resolve_commit(const std::string &commit, git_annotated_com
 
     return {};
 }
+
+Result<git_commit_ptr> Repository::checkout_commit(const std::string &commit) {
+
+    git_annotated_commit_ptr ac_target_commit;
+    git_commit_ptr target_commit;
+    git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
+    checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
+
+    auto rval = resolve_commit(commit, ac_target_commit, target_commit);
+    if (!rval)
+        return unexpected_nested(ErrorCode::GitGenericError, rval.error());
+
+    int err = git_checkout_tree(m_repo.get(), (const git_object *)target_commit.get(), &checkout_opts);
+    if (err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    err = git_repository_set_head_detached_from_annotated(m_repo.get(), ac_target_commit.get());
+    if (err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    return target_commit;
+}
diff --git a/repository.h b/repository.h
index 247004c..7c142ac 100644
--- a/repository.h
+++ b/repository.h
@@ -23,8 +23,10 @@ namespace gitse2 {
 
             std::string m_repo_path {"."};
             git_repository_ptr m_repo;
+
             [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);
             [[nodiscard]] Result<> resolve_commit(const std::string& commit, git_annotated_commit_ptr& gac, git_commit_ptr& gc);
+            [[nodiscard]] Result<git_commit_ptr> checkout_commit(const std::string& commit);
     };
 }
 

```

## 11. Add error callback to explain git errors

The changeset adds a new function `explain_repository_fail` to the `repository.cpp` file. This function retrieves the last git error and appends it to the error message along with the generic error explanation and the specific libgit2 error code. This new function enhances the error handling by providing more detailed information when errors occur during git operations.

```diff
diff --git a/repository.cpp b/repository.cpp
index 94d074f..03ca545 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -42,6 +42,21 @@ static std::string explain_repository_open_fail(const Error& e) {
     return ss.str();
 }
 
+static std::string explain_repository_fail(const Error& e) {
+    const git_error *last_error = giterr_last();
+
+    std::stringstream ss;
+
+    ss << explain_generic(e);
+    ss << "libgit2 error = " << std::any_cast<int>(e.aux);
+    if (last_error) {
+        ss << ", last_error: "<<last_error->message<<"\n";
+    }
+
+    return ss.str();
+}
+
+
 Result<RepositoryRef> Repository::open()
 {
     _initializer->init();

```

## 12. Add functionality to create branch

The changeset includes modifications in the `repository.cpp` and `repository.h` files to add functionality for creating a branch in the Git repository. In `repository.cpp`, a new method `create_branch` is implemented, which creates a branch on the HEAD using the provided branch name and commit. It handles the creation of the branch and returns an empty result upon success. In `repository.h`, the declaration for the `create_branch` method is added to the class definition, allowing users to create branches through this interface.

```diff
diff --git a/repository.cpp b/repository.cpp
index ef13207..03ca545 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -153,3 +153,15 @@ Result<git_commit_ptr> Repository::checkout_commit(const std::string &commit) {
 
     return target_commit;
 }
+
+Result<> Repository::create_branch(const std::string &branch, const git_commit_ptr& commit) {
+    // will be creating branch on HEAD
+
+    git_reference* ref = nullptr; // free reference???
+    int err = git_branch_create(&ref, m_repo.get(), branch.c_str(), commit.get(), 1);
+    if (err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    git_reference_ptr ref_ptr(ref);
+    return {};
+}
diff --git a/repository.h b/repository.h
index 09985e7..7c142ac 100644
--- a/repository.h
+++ b/repository.h
@@ -27,6 +27,7 @@ namespace gitse2 {
             [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);
             [[nodiscard]] Result<> resolve_commit(const std::string& commit, git_annotated_commit_ptr& gac, git_commit_ptr& gc);
             [[nodiscard]] Result<git_commit_ptr> checkout_commit(const std::string& commit);
+            [[nodiscard]] Result<> create_branch(const std::string& branch, const git_commit_ptr& commit);
     };
 }
 

```

## 13. Add functionality to create and apply diff

The changeset includes modifications in both `repository.cpp` and `repository.h` files. In `repository.cpp`, a new function `apply_diff` is added to the `Repository` class. This function takes two `git_commit_ptr` parameters, retrieves the trees associated with the commits, calculates the diff between the trees, applies the diff to the repository, and returns a result. The function is implemented to handle errors and return appropriate error codes if needed.

In `repository.h`, the declaration for the `apply_diff` function is added to the `Repository` class, specifying its parameters and return type. This change ensures that the new functionality is properly declared in the header file for external use.

Overall, these changes introduce the ability to create and apply a diff between two commits in the repository, enhancing the functionality of the `Repository` class.

```diff
diff --git a/repository.cpp b/repository.cpp
index a83b377..03ca545 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -165,3 +165,32 @@ Result<> Repository::create_branch(const std::string &branch, const git_commit_p
     git_reference_ptr ref_ptr(ref);
     return {};
 }
+
+Result<> Repository::apply_diff(const git_commit_ptr &commit1, const git_commit_ptr &commit2) {
+    git_tree* tree1 = nullptr;
+    git_tree* tree2 = nullptr;
+
+    if (auto err = git_commit_tree(&tree1, commit1.get()); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    git_tree_ptr tree1_ptr(tree1);
+
+    if (auto err = git_commit_tree(&tree2, commit2.get()); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    git_tree_ptr tree2_ptr(tree2);
+
+    git_diff *diff = nullptr;
+    if (auto err = git_diff_tree_to_tree(&diff, m_repo.get(), tree1, tree2, NULL); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    git_diff_ptr diff_ptr(diff);
+
+    if (auto err = git_apply(m_repo.get(), diff, GIT_APPLY_LOCATION_BOTH, nullptr); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    // now commit changes
+
+    return {};
+}
+
diff --git a/repository.h b/repository.h
index 5b72b34..7c142ac 100644
--- a/repository.h
+++ b/repository.h
@@ -28,6 +28,7 @@ namespace gitse2 {
             [[nodiscard]] Result<> resolve_commit(const std::string& commit, git_annotated_commit_ptr& gac, git_commit_ptr& gc);
             [[nodiscard]] Result<git_commit_ptr> checkout_commit(const std::string& commit);
             [[nodiscard]] Result<> create_branch(const std::string& branch, const git_commit_ptr& commit);
+            [[nodiscard]] Result<> apply_diff(const git_commit_ptr& commit1, const git_commit_ptr& commit2);
     };
 }
 

```

## 14. Add functionality to squash commits into a separate branch

This changeset adds functionality to the `Repository` class to squash commits into a separate branch. It introduces a new method `squash` that takes the first commit as a parameter. Inside the method, it resolves the head commit, checks out the specified commit, creates a new branch based on the first commit, sets the head to the new branch, applies the diff between the new head and the previous head commit, adds all changes to the index, writes the index, writes the tree, creates a new tree, creates a new commit with the auto-generated message, and returns a success result.

```diff
diff --git a/repository.cpp b/repository.cpp
index ac50e42..03ca545 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -84,10 +84,69 @@ public:
     }
 };
 
+Result<> Repository::squash(const std::string& first_commit) {
+    git_annotated_commit_ptr gac;
+    git_commit_ptr head_commit;
+    if (auto resolve_rval = resolve_commit("HEAD", gac, head_commit); !resolve_rval)
+        return unexpected_nested(ErrorCode::GitGenericError, resolve_rval.error());
+
+    auto rval = checkout_commit(first_commit);
+    if (!rval)
+        return unexpected_nested(ErrorCode::GitGenericError, rval.error());
+
+    git_commit_ptr new_head(std::move(rval.value()));
+
+    const auto new_branch_name = fmt::format("git-se/{}", first_commit);
+    auto rval_branch = create_branch(new_branch_name, new_head);
+    if (!rval_branch)
+        return unexpected_nested(ErrorCode::GitGenericError, rval_branch.error());
+
+    if (auto err = git_repository_set_head(m_repo.get(), fmt::format("refs/heads/git-se/{}", first_commit).c_str()); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_fail, err);
+
+    if (auto apply_rval = apply_diff(new_head, head_commit); !apply_rval)
+        return unexpected_nested(ErrorCode::GitGenericError, rval_branch.error());
+
+    git_oid tree_id, commit_id;
+    git_index *index = nullptr;
+
+    if (auto err = git_repository_index(&index, m_repo.get()); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_fail, err);
+
+    git_index_ptr index_ptr(index);
+
+    if (auto err = git_index_add_all(index, NULL, GIT_INDEX_ADD_DEFAULT, NULL, NULL); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_fail, err);
+
+    if (auto err = git_index_write(index); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_fail, err);
+
+    if (auto err = git_index_write_tree(&tree_id, index); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_fail, err);
+
+    git_tree* tree = nullptr;
+    if (auto err = git_tree_lookup(&tree, m_repo.get(), &tree_id); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_fail, err);
+
+    git_tree_ptr tree_ptr(tree);
+
+    git_signature *sig = NULL;
+    if (auto err = git_signature_now(&sig, "Git SE", "git-se@git-se.se"); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_fail, err);
+
+    git_signature_ptr sig_ptr(sig);
+
+    const git_commit* commit2 = new_head.get();
+
+    if (auto err = git_commit_create_v(
+            &commit_id, m_repo.get(), "HEAD", sig, sig, NULL, "Git SE auto generated message", tree,
+            1, commit2); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_fail, err);
+
     return {};
 }
 
 Repository::~Repository()
 Result<git_annotated_commit_ptr> Repository::resolve_commit(const std::string &commit) {
     int err = 0;
     git_reference *ref = NULL;
diff --git a/repository.h b/repository.h
index c29ed91..7c142ac 100644
--- a/repository.h
+++ b/repository.h
@@ -18,6 +18,7 @@ namespace gitse2 {
 
             static Result<RepositoryRef> open();
             ~Repository();
+            [[nodiscard]] Result<> squash(const std::string& first_commit);
         private:
             Repository() = default;
 

```

## 15. Remove redundant destructor

The changeset removes a redundant destructor from the `Repository` class in both `repository.cpp` and `repository.h` files. In `repository.cpp`, the `Repository::~Repository()` destructor is removed, and the `git_repository_free(m_repo)` call inside the `resolve_commit` function is also removed. In `repository.h`, the declaration of the destructor `~Repository();` is removed.

```diff
diff --git a/repository.cpp b/repository.cpp
index 8ee2985..03ca545 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -146,7 +146,6 @@ Result<> Repository::squash(const std::string& first_commit) {
     return {};
 }
 
-Repository::~Repository()
 Result<git_annotated_commit_ptr> Repository::resolve_commit(const std::string &commit) {
     int err = 0;
     git_reference *ref = NULL;
@@ -174,7 +173,6 @@ Result<git_annotated_commit_ptr> Repository::resolve_commit(const std::string &c
 
 Result<> Repository::resolve_commit(const std::string &commit, git_annotated_commit_ptr &gac, git_commit_ptr &gc)
 {
-    git_repository_free(m_repo);
     auto rval = resolve_commit(commit);
     if (!rval)
         return unexpected_nested(ErrorCode::GitGenericError, rval.error());
diff --git a/repository.h b/repository.h
index e2401b9..7c142ac 100644
--- a/repository.h
+++ b/repository.h
@@ -17,8 +17,7 @@ namespace gitse2 {
             Q_DISABLE_COPY_MOVE(Repository)
 
             static Result<RepositoryRef> open();
-            ~Repository();
             [[nodiscard]] Result<> squash(const std::string& first_commit);
         private:
             Repository() = default;
 

```

## 16. Always use [[nodiscard]]

The changeset modifies the `repository.h` file by adding the `[[nodiscard]]` attribute to the `open()` method of the `Repository` class. Additionally, a new line is added after the `squash()` method declaration. This change ensures that the compiler will produce a warning if the return value of the `open()` method is unintentionally ignored, promoting safer code practices.

```diff
diff --git a/repository.h b/repository.h
index d011553..7c142ac 100644
--- a/repository.h
+++ b/repository.h
@@ -16,8 +16,9 @@ namespace gitse2 {
         public:
             Q_DISABLE_COPY_MOVE(Repository)
 
-            static Result<RepositoryRef> open();
+            [[nodiscard]] static Result<RepositoryRef> open();
             [[nodiscard]] Result<> squash(const std::string& first_commit);
+
         private:
             Repository() = default;
 

```

## 17. Squash from first_commit to head to separate branch on program start

The changeset includes adding a new line of code to squash changes from the `first_commit` to the head onto a separate branch when the program starts. It introduces a new variable `rval` that stores the result of squashing the changes. If the squashing operation fails, an error message is logged, and the program returns with an error code.

```diff
diff --git a/main.cpp b/main.cpp
index 0a7c693..d6e6e64 100644
--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,12 @@ int main(int argc, char *argv[])
         return 2;
     }
 
+    auto rval = repo.value()->squash(options.value().first_commit());
+    if (!rval) {
+        qCritical().noquote() << gitse2::explain_nested_error(rval.error());
+        return 3;
+    }
+
     QQmlApplicationEngine engine;
     const QUrl url(QStringLiteral("qrc:/git-se2/Main.qml"));
     QObject::connect(

```
