### PR TITLE
Squash diff model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ qt_add_qml_module(appgit-se2
         Main.qml
         SOURCES error-handling.h error-handling.cpp program_options.h program_options.cpp
         SOURCES repository.h repository.cpp git-etcetera.h
+        SOURCES squashdiff.h squashdiff.cpp
+        SOURCES squashdifflist.h squashdifflist.cpp
 )
 
 set(BUILD_TESTS OFF)

--- a/Main.qml
+++ b/Main.qml
@@ -37,31 +37,23 @@ Window {
             clip: true
 
             RowLayout {
-                SplitView {
-                    Layout.preferredWidth: scroll_view.width
-                    Layout.preferredHeight: scroll_view.height
+                Repeater {
+                    model: repeater_model
 
-                    TreeView {
-                        id: treeView
-                        clip: true
-                        SplitView.preferredHeight: scroll_view.height
-                        SplitView.preferredWidth: 150
-                    }
+                    SplitView {
+                        Layout.preferredWidth: scroll_view.width
+                        Layout.preferredHeight: scroll_view.height
 
-                    Item {
-                        // here shoud be a patch view
-                    }
-                }
-                SplitView {
-                    Layout.preferredWidth: scroll_view.width
-                    Layout.preferredHeight: scroll_view.height
+                        TreeView {
+                            id: treeView
+                            clip: true
+                            SplitView.preferredHeight: scroll_view.height
+                            SplitView.preferredWidth: 150
+                        }
 
-                    Item {
-                        SplitView.preferredWidth: 150
-                    }
-
-                    Item {
-
+                        Item {
+                            // here shoud be a patch view
+                        }
                     }
                 }
             }

--- a/error-handling.h
+++ b/error-handling.h
@@ -11,6 +11,7 @@ namespace gitse2 {
         FirstCommitOmittedError,
         GitRepositoryOpenError,
         GitGenericError,
+        GitSquashDiffCreateError,
     };
 
     using explain_aux_callback = std::string(*)(const struct Error&);

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,8 @@
 #include <QQmlApplicationEngine>
 #include "program_options.h"
 #include "repository.h"
+#include "squashdifflist.h"
+#include <QQmlContext>
 
 int main(int argc, char *argv[])
 {
@@ -25,7 +27,21 @@ int main(int argc, char *argv[])
         return 3;
     }
 
+    SquashDiffList sdl;
+
+    auto squash_diff = repo.value()->create_squash_diff();
+    if (!squash_diff) {
+        qCritical().noquote() << gitse2::explain_nested_error(squash_diff.error());
+        return 4;
+    }
+
+    sdl.append(std::move(squash_diff.value()));
+
     QQmlApplicationEngine engine;
+
+    auto *context = engine.rootContext();
+    context->setContextProperty("repeater_model", &sdl);
+
     const QUrl url(QStringLiteral("qrc:/git-se2/Main.qml"));
     QObject::connect(
         &engine,

--- a/repository.cpp
+++ b/repository.cpp
@@ -250,8 +250,6 @@ Result<> Repository::apply_diff(const git_commit_ptr &commit1, const git_commit_
     if (auto err = git_apply(m_repo.get(), diff, GIT_APPLY_LOCATION_BOTH, nullptr); err != GIT_OK)
         return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
 
-    // now commit changes
-
     return {};
 }
 

--- a/repository.cpp
+++ b/repository.cpp
@@ -241,8 +241,11 @@ Result<> Repository::apply_diff(const git_commit_ptr &commit1, const git_commit_
 
     git_tree_ptr tree2_ptr(tree2);
 
+    git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
+    opts.flags |= GIT_DIFF_SHOW_BINARY;
+
     git_diff *diff = nullptr;
-    if (auto err = git_diff_tree_to_tree(&diff, m_repo.get(), tree1, tree2, NULL); err != GIT_OK)
+    if (auto err = git_diff_tree_to_tree(&diff, m_repo.get(), tree1, tree2, &opts); err != GIT_OK)
         return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
 
     git_diff_ptr diff_ptr(diff);

--- a/repository.cpp
+++ b/repository.cpp
@@ -146,6 +146,9 @@ Result<> Repository::squash(const std::string& first_commit) {
     return {};
 }
 
+static std::string explain_squash_diff_error(const Error& e) {
+    return fmt::format("{}{}", explain_generic(e), "failed to create squash diff");
+}
 Result<git_annotated_commit_ptr> Repository::resolve_commit(const std::string &commit) {
     int err = 0;
     git_reference *ref = NULL;

--- a/repository.cpp
+++ b/repository.cpp
@@ -94,10 +94,10 @@ Result<> Repository::squash(const std::string& first_commit) {
     if (!rval)
         return unexpected_nested(ErrorCode::GitGenericError, rval.error());
 
-    git_commit_ptr new_head(std::move(rval.value()));
+    m_first_commit = std::move(rval.value());
 
     const auto new_branch_name = fmt::format("git-se/{}", first_commit);
-    auto rval_branch = create_branch(new_branch_name, new_head);
+    auto rval_branch = create_branch(new_branch_name, m_first_commit);
     if (!rval_branch)
         return unexpected_nested(ErrorCode::GitGenericError, rval_branch.error());
 
@@ -136,7 +136,7 @@ Result<> Repository::squash(const std::string& first_commit) {
 
     git_signature_ptr sig_ptr(sig);
 
-    const git_commit* commit2 = new_head.get();
+    const git_commit* commit2 = m_first_commit.get();
 
     if (auto err = git_commit_create_v(
             &commit_id, m_repo.get(), "HEAD", sig, sig, NULL, "Git SE auto generated message", tree,

--- a/repository.h
+++ b/repository.h
@@ -6,6 +6,7 @@
 #include <git2.h>
 #include <QtCore/qglobal.h>
 #include "git-etcetera.h"
+#include "squashdiff.h"
 
 namespace gitse2 {
 
@@ -18,6 +19,7 @@ namespace gitse2 {
 
             [[nodiscard]] static Result<RepositoryRef> open();
             [[nodiscard]] Result<> squash(const std::string& first_commit);
+            [[nodiscard]] Result<SquashDiffPtr> create_squash_diff();
 
         private:
             Repository() = default;

--- a/repository.h
+++ b/repository.h
@@ -24,6 +24,7 @@ namespace gitse2 {
 
             std::string m_repo_path {"."};
             git_repository_ptr m_repo;
+            git_commit_ptr m_first_commit;
 
             [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);
             [[nodiscard]] Result<> resolve_commit(const std::string& commit, git_annotated_commit_ptr& gac, git_commit_ptr& gc);

--- a/repository.h
+++ b/repository.h
@@ -24,6 +24,7 @@ namespace gitse2 {
 
             std::string m_repo_path {"."};
             git_repository_ptr m_repo;
+            git_commit_ptr m_target_head;
             git_commit_ptr m_first_commit;
 
             [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);

--- a/squashdiff.cpp
+++ b/squashdiff.cpp
@@ -1,0 +1,4 @@
+#include "squashdiff.h"
+
+using namespace gitse2;
+

--- a/squashdiff.h
+++ b/squashdiff.h
@@ -1,0 +1,38 @@
+#ifndef SQUASHDIFF_H
+#define SQUASHDIFF_H
+
+#include <memory>
+#include <QtCore/qglobal.h>
+#include <git2.h>
+#include <string>
+#include <vector>
+
+namespace gitse2 {
+
+    class SquashDiff {
+        public:
+
+        struct diff_list_item {
+            git_diff_delta original_delta;
+            std::string m_path_new;
+            std::string m_path_old;
+
+            git_diff_binary original_binary_delta;
+            std::vector<char> binary_data_new;
+            std::vector<char> binary_data_old;
+        };
+
+        using diff_list = std::vector<diff_list_item>;
+
+        private:
+            SquashDiff() = default;
+
+            diff_list m_diff_list;
+
+            friend class Repository;
+    };
+
+    using SquashDiffPtr = std::unique_ptr<SquashDiff>;
+}
+
+#endif // SQUASHDIFF_H

--- a/squashdifflist.cpp
+++ b/squashdifflist.cpp
@@ -1,0 +1,36 @@
+#include "squashdifflist.h"
+
+SquashDiffList::SquashDiffList() {}
+
+void SquashDiffList::append(gitse2::SquashDiffPtr&& diff) {
+    beginInsertRows(QModelIndex(), rowCount(), rowCount());
+    m_list_of_diffs.push_back(std::move(diff));
+    endInsertRows();
+}
+
+int SquashDiffList::rowCount(const QModelIndex &parent) const {
+    return m_list_of_diffs.size();
+}
+
+QVariant SquashDiffList::data(const QModelIndex &index, int role) const {
+    if (!index.isValid()) {
+        return QVariant();
+    }
+
+    if (index.row() >= m_list_of_diffs.size()) {
+        return QVariant();
+    }
+
+    if (role == Qt::DisplayRole || role == ModelDataRole) {
+        return QVariant::fromValue(m_list_of_diffs[index.row()].get());
+    }
+
+    return QVariant();
+}
+
+QHash<int, QByteArray> SquashDiffList::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles[ModelDataRole] = "modelData";
+    return roles;
+}

--- a/squashdifflist.h
+++ b/squashdifflist.h
@@ -1,0 +1,26 @@
+#ifndef SQUASHDIFFLIST_H
+#define SQUASHDIFFLIST_H
+
+#include <QAbstractListModel>
+#include <squashdiff.h>
+
+class SquashDiffList : public QAbstractListModel {
+        Q_OBJECT
+    public:
+        SquashDiffList();
+
+        void append(gitse2::SquashDiffPtr&& diff);
+
+        Q_INVOKABLE virtual int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+        Q_INVOKABLE virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+        Q_INVOKABLE virtual QHash<int, QByteArray> roleNames() const override;
+
+    private:
+        std::vector<gitse2::SquashDiffPtr> m_list_of_diffs;
+
+        enum Roles{
+            ModelDataRole = Qt::UserRole+1
+        };
+};
+
+#endif // SQUASHDIFFLIST_H


### PR DESCRIPTION
## 1. Introduce an error code in case SquashDiff creation failure

A changeset has been introduced to the `error-handling.h` file. It adds a new error code `GitSquashDiffCreateError` to the existing list of error codes. This error code will be used in case there is a failure during the creation of a SquashDiff.

```diff
diff --git a/error-handling.h b/error-handling.h
index e29c596..f9dffa7 100644
--- a/error-handling.h
+++ b/error-handling.h
@@ -11,6 +11,7 @@ namespace gitse2 {
         FirstCommitOmittedError,
         GitRepositoryOpenError,
         GitGenericError,
+        GitSquashDiffCreateError,
     };
 
     using explain_aux_callback = std::string(*)(const struct Error&);

```

## 2. Add explain function for introduced error code

The changeset adds a new static function `explain_squash_diff_error` in the `repository.cpp` file. This function takes an `Error` object as a parameter and returns a formatted string that includes the explanation of the error along with a message indicating that the creation of a squash diff has failed. This function is designed to provide an explanation for the introduced error code related to squash diff creation.

```diff
diff --git a/repository.cpp b/repository.cpp
index 03ca545..965bf62 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -146,6 +146,9 @@ Result<> Repository::squash(const std::string& first_commit) {
     return {};
 }
 
+static std::string explain_squash_diff_error(const Error& e) {
+    return fmt::format("{}{}", explain_generic(e), "failed to create squash diff");
+}
 Result<git_annotated_commit_ptr> Repository::resolve_commit(const std::string &commit) {
     int err = 0;
     git_reference *ref = NULL;

```

## 3. Repository remembers first commit now

The changeset includes modifications in both `repository.cpp` and `repository.h` files. In `repository.cpp`, the `new_head` variable is replaced with `m_first_commit` to store the first commit in the repository. The `new_branch_name` and `create_branch` function now use `m_first_commit` instead of `new_head`. Additionally, the `commit2` variable is updated to use `m_first_commit` instead of `new_head` in the `squash` function.

In `repository.h`, a new member variable `m_first_commit` of type `git_commit_ptr` is added to the `Repository` class to store the first commit in the repository.

```diff
diff --git a/repository.cpp b/repository.cpp
index 8aaae4b..965bf62 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -94,18 +94,18 @@ public:
     if (!rval)
         return unexpected_nested(ErrorCode::GitGenericError, rval.error());
 
-    git_commit_ptr new_head(std::move(rval.value()));
+    m_first_commit = std::move(rval.value());
 
     const auto new_branch_name = fmt::format("git-se/{}", first_commit);
-    auto rval_branch = create_branch(new_branch_name, new_head);
+    auto rval_branch = create_branch(new_branch_name, m_first_commit);
     if (!rval_branch)
         return unexpected_nested(ErrorCode::GitGenericError, rval_branch.error());
 
     if (auto err = git_repository_set_head(m_repo.get(), fmt::format("refs/heads/git-se/{}", first_commit).c_str()); err != GIT_OK)
         return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_fail, err);
 
     if (auto apply_rval = apply_diff(new_head, head_commit); !apply_rval)
         return unexpected_nested(ErrorCode::GitGenericError, rval_branch.error());
 
     git_oid tree_id, commit_id;
     git_index *index = nullptr;
@@ -136,7 +136,7 @@ Result<> Repository::squash(const std::string& first_commit) {
 
     git_signature_ptr sig_ptr(sig);
 
-    const git_commit* commit2 = new_head.get();
+    const git_commit* commit2 = m_first_commit.get();
 
     if (auto err = git_commit_create_v(
             &commit_id, m_repo.get(), "HEAD", sig, sig, NULL, "Git SE auto generated message", tree,
diff --git a/repository.h b/repository.h
index 7c142ac..7568580 100644
--- a/repository.h
+++ b/repository.h
@@ -24,6 +24,7 @@ namespace gitse2 {
 
             std::string m_repo_path {"."};
             git_repository_ptr m_repo;
+            git_commit_ptr m_first_commit;
 
             [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);
             [[nodiscard]] Result<> resolve_commit(const std::string& commit, git_annotated_commit_ptr& gac, git_commit_ptr& gc);

```

## 4. Repository remembers target commit now

The changeset includes modifications in two files: `repository.cpp` and `repository.h`. 

In `repository.cpp`, the `Repository::squash` method has been updated to check if `m_target_head` is not null before resolving the commit for `"HEAD"`. If `m_target_head` is null, it resolves the commit for `"HEAD"` and assigns it to `m_target_head`. Additionally, the `apply_diff` function now uses `m_first_commit` and `m_target_head` as parameters.

In `repository.h`, a new member variable `git_commit_ptr m_target_head;` has been added to the `Repository` class.

These changes ensure that the repository now remembers the target commit, allowing for more efficient handling of commits in the codebase.

```diff
diff --git a/repository.cpp b/repository.cpp
index 020d848..965bf62 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -86,9 +86,10 @@ public:
 
 Result<> Repository::squash(const std::string& first_commit) {
     git_annotated_commit_ptr gac;
-    git_commit_ptr head_commit;
-    if (auto resolve_rval = resolve_commit("HEAD", gac, head_commit); !resolve_rval)
-        return unexpected_nested(ErrorCode::GitGenericError, resolve_rval.error());
+    if (!m_target_head) {
+        if (auto resolve_rval = resolve_commit("HEAD", gac, m_target_head); !resolve_rval)
+            return unexpected_nested(ErrorCode::GitGenericError, resolve_rval.error());
+    }
 
     auto rval = checkout_commit(first_commit);
     if (!rval)
@@ -104,8 +105,8 @@ Result<> Repository::squash(const std::string& first_commit) {
     if (auto err = git_repository_set_head(m_repo.get(), fmt::format("refs/heads/git-se/{}", first_commit).c_str()); err != GIT_OK)
         return unexpected_explained(ErrorCode::GitRepositoryOpenError, explain_repository_fail, err);
 
-    if (auto apply_rval = apply_diff(new_head, head_commit); !apply_rval)
-        return unexpected_nested(ErrorCode::GitGenericError, rval_branch.error());
+    if (auto apply_rval = apply_diff(m_first_commit, m_target_head); !apply_rval)
+        return unexpected_nested(ErrorCode::GitGenericError, apply_rval.error());
 
     git_oid tree_id, commit_id;
     git_index *index = nullptr;
diff --git a/repository.h b/repository.h
index 42b7b27..7568580 100644
--- a/repository.h
+++ b/repository.h
@@ -24,6 +24,7 @@ namespace gitse2 {
 
             std::string m_repo_path {"."};
             git_repository_ptr m_repo;
+            git_commit_ptr m_target_head;
             git_commit_ptr m_first_commit;
 
             [[nodiscard]] Result<git_annotated_commit_ptr> resolve_commit(const std::string& commit);

```

## 5. Remove redundant comment

This changeset removes a redundant comment in the `repository.cpp` file. The comment "now commit changes" has been deleted from line 250 of the file. The patch aims to improve code readability by eliminating unnecessary or redundant comments.

```diff
diff --git a/repository.cpp b/repository.cpp
index 88be8da..965bf62 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -250,8 +250,6 @@ Result<> Repository::apply_diff(const git_commit_ptr &commit1, const git_commit_
     if (auto err = git_apply(m_repo.get(), diff, GIT_APPLY_LOCATION_BOTH, nullptr); err != GIT_OK)
         return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
 
-    // now commit changes
-
     return {};
 }
 

```

## 6. Method `apply_diff` is now using GIT_DIFF_SHOW_BINARY flag

The changeset modifies the `apply_diff` method in the `repository.cpp` file. It introduces a new `git_diff_options` variable `opts` initialized with `GIT_DIFF_OPTIONS_INIT`. The `GIT_DIFF_SHOW_BINARY` flag is set in the `opts` variable. This flag is then passed to the `git_diff_tree_to_tree` function as a parameter to indicate that binary files should be shown in the diff.

```diff
diff --git a/repository.cpp b/repository.cpp
index d73d54a..965bf62 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -241,8 +241,11 @@ Result<> Repository::apply_diff(const git_commit_ptr &commit1, const git_commit_
 
     git_tree_ptr tree2_ptr(tree2);
 
+    git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
+    opts.flags |= GIT_DIFF_SHOW_BINARY;
+
     git_diff *diff = nullptr;
-    if (auto err = git_diff_tree_to_tree(&diff, m_repo.get(), tree1, tree2, NULL); err != GIT_OK)
+    if (auto err = git_diff_tree_to_tree(&diff, m_repo.get(), tree1, tree2, &opts); err != GIT_OK)
         return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
 
     git_diff_ptr diff_ptr(diff);

```

## 7. Introduce SquashDiff: storage for diffs

This changeset introduces a new storage class called `SquashDiff` by adding two new files: `squashdiff.cpp` and `squashdiff.h`. 

In `squashdiff.cpp`, the file is created with the inclusion of `squashdiff.h` header file and the usage of the `gitse2` namespace.

In `squashdiff.h`, a new class `SquashDiff` is defined within the `gitse2` namespace. This class contains a struct `diff_list_item` with various data members related to storing diff information. Additionally, a `diff_list` type alias is defined as a vector of `diff_list_item`. The class also includes a private member `m_diff_list` of type `diff_list`. The class has a private constructor and is a friend of the `Repository` class. Finally, a type alias `SquashDiffPtr` is defined as a unique pointer to `SquashDiff`.

These changes set up the foundation for storing and managing diff information within the `SquashDiff` class.

```diff
diff --git a/squashdiff.cpp b/squashdiff.cpp
new file mode 100644
index 0000000..1cd2164
--- /dev/null
+++ b/squashdiff.cpp
@@ -0,0 +1,4 @@
+#include "squashdiff.h"
+
+using namespace gitse2;
+
diff --git a/squashdiff.h b/squashdiff.h
new file mode 100644
index 0000000..898e22f
--- /dev/null
+++ b/squashdiff.h
@@ -0,0 +1,38 @@
+#ifndef SQUASHDIFF_H
+#define SQUASHDIFF_H
+
+#include <memory>
+#include <QtCore/qglobal.h>
+#include <git2.h>
+#include <string>
+#include <vector>
+
+namespace gitse2 {
+
+    class SquashDiff {
+        public:
+
+        struct diff_list_item {
+            git_diff_delta original_delta;
+            std::string m_path_new;
+            std::string m_path_old;
+
+            git_diff_binary original_binary_delta;
+            std::vector<char> binary_data_new;
+            std::vector<char> binary_data_old;
+        };
+
+        using diff_list = std::vector<diff_list_item>;
+
+        private:
+            SquashDiff() = default;
+
+            diff_list m_diff_list;
+
+            friend class Repository;
+    };
+
+    using SquashDiffPtr = std::unique_ptr<SquashDiff>;
+}
+
+#endif // SQUASHDIFF_H

```

## 8. Introduce SquashDiffList model for Repeator

This changeset introduces a new model called `SquashDiffList` for the Repeator. It includes two new files: `squashdifflist.cpp` and `squashdifflist.h`. 

In `squashdifflist.cpp`, the `SquashDiffList` class is defined with methods to append a `SquashDiffPtr`, retrieve the row count, and provide data for a specific index. It also includes a method to define role names for the model. 

In `squashdifflist.h`, the header file for the `SquashDiffList` class is declared. It includes necessary headers, defines the class inheriting from `QAbstractListModel`, and declares methods for appending a `SquashDiffPtr`, getting the row count, retrieving data, and defining role names. Additionally, it includes a private member to store a list of `SquashDiffPtr` objects and an enum for roles.

These changes aim to provide a model that can be used with the Repeator to manage and display a list of `SquashDiff` objects efficiently.

```diff
diff --git a/squashdifflist.cpp b/squashdifflist.cpp
new file mode 100644
index 0000000..3c34e21
--- /dev/null
+++ b/squashdifflist.cpp
@@ -0,0 +1,36 @@
+#include "squashdifflist.h"
+
+SquashDiffList::SquashDiffList() {}
+
+void SquashDiffList::append(gitse2::SquashDiffPtr&& diff) {
+    beginInsertRows(QModelIndex(), rowCount(), rowCount());
+    m_list_of_diffs.push_back(std::move(diff));
+    endInsertRows();
+}
+
+int SquashDiffList::rowCount(const QModelIndex &parent) const {
+    return m_list_of_diffs.size();
+}
+
+QVariant SquashDiffList::data(const QModelIndex &index, int role) const {
+    if (!index.isValid()) {
+        return QVariant();
+    }
+
+    if (index.row() >= m_list_of_diffs.size()) {
+        return QVariant();
+    }
+
+    if (role == Qt::DisplayRole || role == ModelDataRole) {
+        return QVariant::fromValue(m_list_of_diffs[index.row()].get());
+    }
+
+    return QVariant();
+}
+
+QHash<int, QByteArray> SquashDiffList::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles[ModelDataRole] = "modelData";
+    return roles;
+}
diff --git a/squashdifflist.h b/squashdifflist.h
new file mode 100644
index 0000000..ae68974
--- /dev/null
+++ b/squashdifflist.h
@@ -0,0 +1,26 @@
+#ifndef SQUASHDIFFLIST_H
+#define SQUASHDIFFLIST_H
+
+#include <QAbstractListModel>
+#include <squashdiff.h>
+
+class SquashDiffList : public QAbstractListModel {
+        Q_OBJECT
+    public:
+        SquashDiffList();
+
+        void append(gitse2::SquashDiffPtr&& diff);
+
+        Q_INVOKABLE virtual int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+        Q_INVOKABLE virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+        Q_INVOKABLE virtual QHash<int, QByteArray> roleNames() const override;
+
+    private:
+        std::vector<gitse2::SquashDiffPtr> m_list_of_diffs;
+
+        enum Roles{
+            ModelDataRole = Qt::UserRole+1
+        };
+};
+
+#endif // SQUASHDIFFLIST_H

```

## 9. Introduce a method that creates SquashDiff

A `changeset` has been introduced to the `repository.cpp` file which adds a new method `create_squash_diff()` to the `Repository` class. This method is responsible for creating a `SquashDiff` object by performing various Git operations such as obtaining tree pointers, calculating the diff between two trees, and populating the `SquashDiff` object with relevant data. Additionally, error handling and callbacks for processing file and binary differences are implemented within this method.

In the `repository.h` file, a `changeset` has been made to include the header file `"squashdiff.h"` in the `Repository` class. This change allows the declaration of the new method `create_squash_diff()` which returns a `Result` containing a pointer to a `SquashDiff` object.

```diff
diff --git a/repository.cpp b/repository.cpp
index c3a81b4..965bf62 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -150,6 +150,79 @@ Result<> Repository::squash(const std::string& first_commit) {
 static std::string explain_squash_diff_error(const Error& e) {
     return fmt::format("{}{}", explain_generic(e), "failed to create squash diff");
 }
+
+Result<SquashDiffPtr> Repository::create_squash_diff() {
+    if (!m_target_head)
+        return unexpected_explained(ErrorCode::GitSquashDiffCreateError, explain_squash_diff_error, 0);
+    if (!m_first_commit)
+        return unexpected_explained(ErrorCode::GitSquashDiffCreateError, explain_squash_diff_error, 0);
+
+    git_annotated_commit_ptr gac;
+
+    git_tree* tree1 = nullptr;
+    if (auto err = git_commit_tree(&tree1, m_first_commit.get()); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    git_tree_ptr tree1_ptr(tree1);
+
+    git_tree* tree2 = nullptr;
+    if (auto err = git_commit_tree(&tree2, m_target_head.get()); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    git_tree_ptr tree2_ptr(tree2);
+
+    git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
+    opts.flags |= GIT_DIFF_SHOW_BINARY;
+
+    git_diff *diff = nullptr;
+    if (auto err = git_diff_tree_to_tree(&diff, m_repo.get(), tree1, tree2, &opts); err != GIT_OK)
+        return unexpected_explained(ErrorCode::GitGenericError, explain_repository_fail, err);
+
+    git_diff_ptr diff_ptr(diff);
+
+    SquashDiffPtr sd(new SquashDiff());
+    sd->m_diff_list.reserve(10);
+
+    auto file_cb = [](const git_diff_delta *delta, float progress, void *payload) -> int {
+        SquashDiff::diff_list* lod = reinterpret_cast<SquashDiff::diff_list*>(payload);
+        SquashDiff::diff_list_item item;
+
+        item.original_delta = *delta;
+        if (delta->new_file.path) item.m_path_new = delta->new_file.path;
+        if (delta->old_file.path) item.m_path_old = delta->old_file.path;
+
+        item.original_delta.new_file.path = item.m_path_new.c_str();
+        item.original_delta.old_file.path = item.m_path_old.c_str();
+
+        qDebug() << "diff, new: "<<item.m_path_new<<", old: "<<item.m_path_old;
+        lod->push_back(std::move(item));
+        return GIT_OK;
+    };
+
+    auto binary_cb = [](const git_diff_delta *delta, const git_diff_binary *binary, void *payload) -> int {
+        auto& sd = *reinterpret_cast<SquashDiff::diff_list*>(payload);
+        if (binary->contains_data) {
+            auto& item = sd.back();
+            item.original_binary_delta = *binary;
+            if (binary->new_file.datalen > 0) {
+                item.binary_data_new.resize(binary->new_file.datalen);
+                memcpy(item.binary_data_new.data(), binary->new_file.data, binary->new_file.datalen);
+            }
+            if (binary->old_file.datalen > 0) {
+                item.binary_data_old.resize(binary->old_file.datalen);
+                memcpy(item.binary_data_old.data(), binary->old_file.data, binary->old_file.datalen);
+            }
+            item.original_binary_delta.new_file.data = item.binary_data_new.data();
+            item.original_binary_delta.old_file.data = item.binary_data_old.data();
+        }
+        return GIT_OK;
+    };
+
+    git_diff_foreach(diff, file_cb , binary_cb, nullptr, nullptr, &sd->m_diff_list);
+
+    return sd;
+}
+
 Result<git_annotated_commit_ptr> Repository::resolve_commit(const std::string &commit) {
     int err = 0;
     git_reference *ref = NULL;
diff --git a/repository.h b/repository.h
index 33fb46d..7568580 100644
--- a/repository.h
+++ b/repository.h
@@ -6,6 +6,7 @@
 #include <git2.h>
 #include <QtCore/qglobal.h>
 #include "git-etcetera.h"
+#include "squashdiff.h"
 
 namespace gitse2 {
 
@@ -18,6 +19,7 @@ namespace gitse2 {
 
             [[nodiscard]] static Result<RepositoryRef> open();
             [[nodiscard]] Result<> squash(const std::string& first_commit);
+            [[nodiscard]] Result<SquashDiffPtr> create_squash_diff();
 
         private:
             Repository() = default;

```

## 10. Use Repeator in QML

The changeset modifies the `Main.qml` file by replacing the existing `SplitView` with a `Repeater` element. Inside the `Repeater`, a `SplitView` is added with a `TreeView` component and an `Item` placeholder. The `Repeater` is set to use a model named `repeater_model`. The layout properties like `Layout.preferredWidth` and `Layout.preferredHeight` are adjusted accordingly within the `SplitView`.

```diff
diff --git a/Main.qml b/Main.qml
index 9240f6d..a662122 100644
--- a/Main.qml
+++ b/Main.qml
@@ -37,31 +37,23 @@ Window {
             clip: true
 
             RowLayout {
-                SplitView {
-                    Layout.preferredWidth: scroll_view.width
-                    Layout.preferredHeight: scroll_view.height
-
-                    TreeView {
-                        id: treeView
-                        clip: true
-                        SplitView.preferredHeight: scroll_view.height
-                        SplitView.preferredWidth: 150
-                    }
-
-                    Item {
-                        // here shoud be a patch view
-                    }
-                }
-                SplitView {
-                    Layout.preferredWidth: scroll_view.width
-                    Layout.preferredHeight: scroll_view.height
-
-                    Item {
-                        SplitView.preferredWidth: 150
-                    }
-
-                    Item {
-
+                Repeater {
+                    model: repeater_model
+
+                    SplitView {
+                        Layout.preferredWidth: scroll_view.width
+                        Layout.preferredHeight: scroll_view.height
+
+                        TreeView {
+                            id: treeView
+                            clip: true
+                            SplitView.preferredHeight: scroll_view.height
+                            SplitView.preferredWidth: 150
+                        }
+
+                        Item {
+                            // here shoud be a patch view
+                        }
                     }
                 }
             }

```

## 11. Create SquashDiff model and propagate it to QML

This changeset adds a new model called `SquashDiff` along with its corresponding implementation files `squashdiff.h` and `squashdiff.cpp` to the QML module in the `CMakeLists.txt` file. Additionally, it includes a new header file `squashdifflist.h` and its implementation file `squashdifflist.cpp` to the QML module.

In the `main.cpp` file, this changeset introduces the inclusion of `squashdifflist.h` and `<QQmlContext>`. It also creates an instance of `SquashDiffList` named `sdl`, creates a `squash_diff` object using a method from `repo`, handles errors if the `squash_diff` creation fails, appends the `squash_diff` to `sdl`, sets `sdl` as a context property named `repeater_model` in the QML engine's root context.

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index b4ee5ed..5c2016e 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ qt_add_qml_module(appgit-se2
         Main.qml
         SOURCES error-handling.h error-handling.cpp program_options.h program_options.cpp
         SOURCES repository.h repository.cpp git-etcetera.h
+        SOURCES squashdiff.h squashdiff.cpp
+        SOURCES squashdifflist.h squashdifflist.cpp
 )
 
 set(BUILD_TESTS OFF)
diff --git a/main.cpp b/main.cpp
index d6e6e64..8b53bcc 100644
--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,8 @@ 
 #include <QQmlApplicationEngine>
 #include "program_options.h"
 #include "repository.h"
+#include "squashdifflist.h"
+#include <QQmlContext>
 
 int main(int argc, char *argv[])
 {
@@ -25,7 +27,21 @@ int main(int argc, char *argv[])
         return 3;
     }
 
+    SquashDiffList sdl;
+
+    auto squash_diff = repo.value()->create_squash_diff();
+    if (!squash_diff) {
+        qCritical().noquote() << gitse2::explain_nested_error(squash_diff.error());
+        return 4;
+    }
+
+    sdl.append(std::move(squash_diff.value()));
+
     QQmlApplicationEngine engine;
+
+    auto *context = engine.rootContext();
+    context->setContextProperty("repeater_model", &sdl);
+
     const QUrl url(QStringLiteral("qrc:/git-se2/Main.qml"));
     QObject::connect(
         &engine,

```
