### PR TITLE
Tree view qml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ qt_add_qml_module(gitse2
     SOURCES repository.h repository.cpp git-etcetera.h
     SOURCES squashdiff.h squashdiff.cpp
     SOURCES squashdifflist.h squashdifflist.cpp
+    SOURCES difftreeitem.h difftreeitem.cpp
+    SOURCES difflistitem.h difflistitem.cpp
+    SOURCES difftreemodel.h difftreemodel.cpp
 )
 
 set(BUILD_TESTS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(git-se2 VERSION 0.1 LANGUAGES CXX)
+project(gitse2 VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -8,19 +8,20 @@ find_package(Qt6 6.4 REQUIRED COMPONENTS Quick QuickControls2)
 
 qt_standard_project_setup()
 
-qt_add_executable(appgit-se2
+qt_add_executable(gitse2
     main.cpp
 )
 
-qt_add_qml_module(appgit-se2
-    URI git-se2
+qt_policy(set QTP0001 NEW)
+
+qt_add_qml_module(gitse2
+    URI ldd.so.gitse2
     VERSION 1.0
-    QML_FILES
-        Main.qml
-        SOURCES error-handling.h error-handling.cpp program_options.h program_options.cpp
-        SOURCES repository.h repository.cpp git-etcetera.h
-        SOURCES squashdiff.h squashdiff.cpp
-        SOURCES squashdifflist.h squashdifflist.cpp
+    QML_FILES Main.qml
+    SOURCES error-handling.h error-handling.cpp program_options.h program_options.cpp
+    SOURCES repository.h repository.cpp git-etcetera.h
+    SOURCES squashdiff.h squashdiff.cpp
+    SOURCES squashdifflist.h squashdifflist.cpp
 )
 
 set(BUILD_TESTS OFF)
@@ -41,21 +42,21 @@ add_subdirectory(libfmt)
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.
 # If you are developing for iOS or macOS you should consider setting an
 # explicit, fixed bundle identifier manually though.
-set_target_properties(appgit-se2 PROPERTIES
-#    MACOSX_BUNDLE_GUI_IDENTIFIER com.example.appgit-se2
+set_target_properties(gitse2 PROPERTIES
+#    MACOSX_BUNDLE_GUI_IDENTIFIER gitse2
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
     MACOSX_BUNDLE TRUE
     WIN32_EXECUTABLE TRUE
 )
 
-target_include_directories(appgit-se2 PRIVATE ${PROJECT_SOURCE_DIR}/libgit2/include)
-target_link_libraries(appgit-se2
+target_include_directories(gitse2 PRIVATE ${PROJECT_SOURCE_DIR}/libgit2/include)
+target_link_libraries(gitse2
     PRIVATE Qt6::Quick Qt6::QuickControls2 libgit2package expected fmt
 )
 
 include(GNUInstallDirs)
-install(TARGETS appgit-se2
+install(TARGETS gitse2
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/Main.qml
+++ b/Main.qml
@@ -7,11 +7,12 @@ Window {
     width: 640
     height: 480
     visible: true
-    title: qsTr("Hello World")
+    title: qsTr("Git Split-Explain")
     id: win
 
-    Material.theme: Material.Dark
+    //Material.theme: Material.Blue
     Material.accent: Material.Blue
+    //Material.background: Material.White
 
     ColumnLayout {
         id: col
@@ -22,11 +23,14 @@ Window {
             id: bar
             Layout.preferredHeight: 50
             Layout.preferredWidth: col.width
-            TabButton {
-                text: qsTr("Tab1")
-            }
-            TabButton {
-                text: qsTr("Tab2")
+
+            Repeater {
+                model: repeater_model
+
+                TabButton {
+                    text: modelData.title
+                }
+
             }
         }
 
@@ -49,6 +53,89 @@ Window {
                             clip: true
                             SplitView.preferredHeight: scroll_view.height
                             SplitView.preferredWidth: 150
+                            model: modelData.tree_model
+                            alternatingRows: false
+                            selectionModel: ItemSelectionModel {}
+
+                            delegate: Item {
+                                width: treeView.width
+                                height: 30
+                                implicitHeight: 30
+                                implicitWidth: treeView.width
+
+                                readonly property real indentation: 20
+                                required property int depth
+                                required property int hasChildren
+                                required property bool current
+                                required property bool expanded
+                                required property bool isTreeNode
+
+                                // Rotate indicator when expanded by the user
+                                // (requires TreeView to have a selectionModel)
+                                property Animation indicatorAnimation: NumberAnimation {
+                                    target: indicator
+                                    property: "rotation"
+                                    from: expanded ? 0 : 90
+                                    to: expanded ? 90 : 0
+                                    duration: 100
+                                    easing.type: Easing.OutQuart
+                                }
+                                TableView.onPooled: indicatorAnimation.complete()
+                                TableView.onReused: if (current) indicatorAnimation.start()
+                                onExpandedChanged: indicator.rotation = expanded ? 90 : 0
+
+                                MouseArea {
+                                    id: globalMouseArea
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: containsMouse ? Qt.ClosedHandCursor : Qt.ArrowCursor
+                                }
+
+                                Rectangle {
+                                    id: background
+                                    anchors.fill: parent
+                                    color: Material.background
+                                    //color: row === treeView.currentRow ? palette.highlight : "black"
+                                    // opacity: (treeView.alternatingRows && row % 2 !== 0) ? 0.3 : 0.1
+                                }
+
+                                Label {
+                                    id: indicator
+                                    x: padding + (depth * indentation)
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    visible: isTreeNode && hasChildren
+                                    text: "▶"
+
+                                    TapHandler {
+                                        onSingleTapped: {
+                                            let index = treeView.index(row, column)
+                                            // treeView.selectionModel.setCurrentIndex(index, ItemSelectionModel.NoUpdate)
+                                            treeView.toggleExpanded(row)
+                                        }
+                                    }
+                                }
+
+                                Label {
+                                    id: label
+                                    x: padding + (isTreeNode ? (depth + 1) * indentation : 0)
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    width: parent.width - padding - x
+                                    clip: true
+                                    text: model.display
+                                    color: model.diff_type
+                                    font.bold: current && !hasChildren
+
+                                    TapHandler {
+                                        onSingleTapped: {
+                                            if (hasChildren) {
+                                                treeView.toggleExpanded(row)
+                                            } else {
+                                                treeView.selectionModel.setCurrentIndex(treeView.index(row, column), ItemSelectionModel.NoUpdate)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
 
                         Item {

--- a/difflistitem.cpp
+++ b/difflistitem.cpp
@@ -1,0 +1,34 @@
+#include "difflistitem.h"
+#include <memory.h>
+
+void DiffListItem::add_delta(const git_diff_delta* delta) {
+    m_original_delta = *delta;
+    if (delta->new_file.path) m_path_new = delta->new_file.path;
+    if (delta->old_file.path) m_path_old = delta->old_file.path;
+
+    m_original_delta.new_file.path = m_path_new.c_str();
+    m_original_delta.old_file.path = m_path_old.c_str();
+}
+
+void DiffListItem::add_binary_delta(const git_diff_binary *binary) {
+    m_original_binary_delta = *binary;
+    if (binary->new_file.datalen > 0) {
+        m_binary_data_new.resize(binary->new_file.datalen);
+        memcpy(m_binary_data_new.data(), binary->new_file.data, binary->new_file.datalen);
+    }
+    if (binary->old_file.datalen > 0) {
+        m_binary_data_old.resize(binary->old_file.datalen);
+        memcpy(m_binary_data_old.data(), binary->old_file.data, binary->old_file.datalen);
+    }
+    m_original_binary_delta.new_file.data = m_binary_data_new.data();
+    m_original_binary_delta.old_file.data = m_binary_data_old.data();
+
+}
+
+const std::string &DiffListItem::path() const {
+    return m_path_new;
+}
+
+int DiffListItem::status() const {
+    return m_original_delta.status;
+}

--- a/difflistitem.h
+++ b/difflistitem.h
@@ -1,0 +1,33 @@
+#ifndef DIFFLISTITEM_H
+#define DIFFLISTITEM_H
+
+#include <git2.h>
+#include <string>
+#include <vector>
+#include <memory>
+
+class DiffListItem
+{
+    public:
+        DiffListItem() = default;
+
+        void add_delta(const git_diff_delta* d);
+        void add_binary_delta(const git_diff_binary* d);
+
+        [[nodiscard]] const std::string& path() const;
+        [[nodiscard]] int status() const;
+
+    private:
+        git_diff_delta m_original_delta;
+        std::string m_path_new;
+        std::string m_path_old;
+
+        git_diff_binary m_original_binary_delta;
+        std::vector<char> m_binary_data_new;
+        std::vector<char> m_binary_data_old;
+};
+
+using DiffListItemPtr = std::shared_ptr<DiffListItem>;
+using DiffList = std::vector<DiffListItemPtr>;
+
+#endif // DIFFLISTITEM_H

--- a/difftreeitem.cpp
+++ b/difftreeitem.cpp
@@ -1,0 +1,65 @@
+#include "difftreeitem.h"
+#include <filesystem>
+
+
+gitse2::Result<DiffTreeItemPtr> DiffTreeItem::createTree(const DiffList &list) {
+    DiffTreeItemPtr root(new DiffTreeItem);
+
+    for (const auto& item : list) {
+        qDebug().noquote()<<"========== SPLIT ========="<<item->path().c_str() << "  status: "<<item->status();
+        auto it = root.get();
+        for (const auto& p : std::filesystem::path(item->path())) {
+            qDebug().noquote() << p.c_str();
+            it = it->add_child(p.c_str());
+        }
+        it->m_diff_ptr = item.get();
+    }
+    return root;
+}
+
+DiffTreeItem *DiffTreeItem::child(int row) const {
+    return row >= 0 && row < childCount() ? m_children.at(row).get() : nullptr;
+}
+
+int DiffTreeItem::childCount() const {
+    return m_children.size();
+}
+
+DiffTreeItem *DiffTreeItem::parentItem() const {
+    return m_parentItem;
+}
+
+int DiffTreeItem::row() const {
+    return m_index;
+}
+
+int DiffTreeItem::columnCount() const {
+    return 1;
+}
+
+QVariant DiffTreeItem::data(int column) const {
+    return m_data;
+}
+
+DiffListItem *DiffTreeItem::diff() const {
+    return m_diff_ptr;
+}
+
+DiffTreeItem* DiffTreeItem::add_child(const std::string &child_name) {
+    // first, look for the child in the list
+    for (const auto& child : m_children) {
+        if (child->data(0).toString().toStdString() == child_name) {
+            // this child is already existed
+            return child.get();
+        }
+    }
+
+    // there's no such child, create a new one
+    DiffTreeItemPtr new_child(new DiffTreeItem);
+    new_child->m_data = QString::fromStdString(child_name);
+    new_child->m_parentItem = this;
+    new_child->m_index = m_children.size();
+    m_children.push_back(std::move(new_child));
+
+    return m_children.back().get();
+}

--- a/difftreeitem.h
+++ b/difftreeitem.h
@@ -1,0 +1,37 @@
+#ifndef DIFFTREEITEM_H
+#define DIFFTREEITEM_H
+
+#include <vector>
+#include <memory>
+#include "difflistitem.h"
+#include "error-handling.h"
+#include <QVariant>
+
+using DiffTreeItemPtr = std::unique_ptr<class DiffTreeItem>;
+using DiffTreeItemList = std::vector<DiffTreeItemPtr>;
+
+class DiffTreeItem
+{
+    public:
+        [[nodiscard]] static gitse2::Result<DiffTreeItemPtr> createTree(const DiffList& list);
+        [[nodiscard]] DiffTreeItem* child(int row) const;
+        [[nodiscard]] int childCount() const;
+        [[nodiscard]] DiffTreeItem* parentItem() const;
+        [[nodiscard]] int row() const;
+        [[nodiscard]] int columnCount() const;
+        [[nodiscard]] QVariant data(int column) const;
+        [[nodiscard]] DiffListItem* diff() const;
+
+        [[nodiscard]] DiffTreeItem* add_child(const std::string& child_name);
+    private:
+        DiffTreeItem() = default;
+
+    private:
+        DiffTreeItemList m_children;
+        DiffTreeItem* m_parentItem {nullptr};
+        DiffListItem* m_diff_ptr {nullptr};
+        int m_index {0};
+        QVariant m_data {"root"};
+};
+
+#endif // DIFFTREEITEM_H

--- a/difftreemodel.cpp
+++ b/difftreemodel.cpp
@@ -1,0 +1,86 @@
+#include "difftreemodel.h"
+#include <git2.h>
+
+gitse2::Result<DiffTreeModelPtr> DiffTreeModel::create_model(const DiffList &list) {
+
+    DiffTreeModelPtr model (new DiffTreeModel());
+
+    auto rval = DiffTreeItem::createTree(list);
+    if (!rval)
+        return unexpected_error(gitse2::ErrorCode::GitSquashDiffCreateError);
+    model->m_root = std::move(rval.value());
+    return model;
+}
+
+QModelIndex DiffTreeModel::index(int row, int column, const QModelIndex &parent) const {
+    if (!hasIndex(row, column, parent))
+        return {};
+
+    DiffTreeItem *parentItem = parent.isValid()
+                               ? static_cast<DiffTreeItem*>(parent.internalPointer())
+                               : m_root.get();
+
+    if (auto *childItem = parentItem->child(row))
+        return createIndex(row, column, childItem);
+
+    return {};
+}
+
+QModelIndex DiffTreeModel::parent(const QModelIndex &index) const {
+    if (!index.isValid())
+        return {};
+
+    DiffTreeItem *childItem = static_cast<DiffTreeItem*>(index.internalPointer());
+    DiffTreeItem *parentItem = childItem->parentItem();
+
+    return parentItem != m_root.get()
+               ? createIndex(parentItem->row(), 0, parentItem) : QModelIndex{};
+}
+
+int DiffTreeModel::rowCount(const QModelIndex &parent) const {
+    if (parent.column() > 0)
+        return 0;
+
+    const DiffTreeItem *parentItem = parent.isValid()
+                                     ? static_cast<const DiffTreeItem*>(parent.internalPointer())
+                                     : m_root.get();
+    return parentItem->childCount();
+}
+
+int DiffTreeModel::columnCount(const QModelIndex &parent) const {
+    if (parent.isValid())
+        return static_cast<DiffTreeItem*>(parent.internalPointer())->columnCount();
+    return m_root->columnCount();
+}
+
+QVariant DiffTreeModel::data(const QModelIndex &index, int role) const {
+    if (!index.isValid() || !(role == Qt::DisplayRole || role == DiffTypeRole))
+        return {};
+
+    const auto *item = static_cast<const DiffTreeItem*>(index.internalPointer());
+
+    if (role == DiffTypeRole) {
+        auto diff = item->diff();
+        if (diff) {
+            switch (diff->status()) {
+                case GIT_DELTA_ADDED:
+                    return "green";
+                case GIT_DELTA_DELETED:
+                    return "red";
+                case GIT_DELTA_MODIFIED:
+                    return "brown";
+                default:
+                    break;
+            }
+        }
+    }
+
+    return item->data(index .column());
+}
+
+QHash<int, QByteArray> DiffTreeModel::roleNames() const {
+    QHash<int, QByteArray> roles;
+    roles[Qt::DisplayRole] = "display";
+    roles[DiffTypeRole] = "diff_type";
+    return roles;
+}

--- a/difftreemodel.h
+++ b/difftreemodel.h
@@ -1,0 +1,32 @@
+#ifndef DIFFTREEMODEL_H
+#define DIFFTREEMODEL_H
+
+#include <QAbstractItemModel>
+#include "difftreeitem.h"
+#include "error-handling.h"
+
+using DiffTreeModelPtr = std::unique_ptr<class DiffTreeModel>;
+
+class DiffTreeModel : public QAbstractItemModel {
+    Q_OBJECT
+    public:
+        Q_DISABLE_COPY_MOVE(DiffTreeModel)
+
+        [[nodiscard]] static gitse2::Result<DiffTreeModelPtr> create_model(const DiffList& list);
+        Q_INVOKABLE virtual QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+        [[nodiscard]] QModelIndex parent(const QModelIndex &index) const override;
+        [[nodiscard]] int rowCount(const QModelIndex &parent = {}) const override;
+        [[nodiscard]] int columnCount(const QModelIndex &parent = {}) const override;
+        [[nodiscard]] QVariant data(const QModelIndex &index, int role) const override;
+        [[nodiscard]] virtual QHash<int,QByteArray> roleNames() const override;
+    private:
+        DiffTreeModel() = default;
+        DiffTreeItemPtr m_root;
+
+        enum Roles{
+            DiffTypeRole = Qt::UserRole+1
+        };
+
+};
+
+#endif // DIFFTREEMODEL_H

--- a/main.cpp
+++ b/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
     auto *context = engine.rootContext();
     context->setContextProperty("repeater_model", &sdl);
 
-    const QUrl url(QStringLiteral("qrc:/git-se2/Main.qml"));
+    const QUrl url(QStringLiteral("qrc:/ldd/so/gitse2/Main.qml"));
     QObject::connect(
         &engine,
         &QQmlApplicationEngine::objectCreationFailed,

--- a/repository.cpp
+++ b/repository.cpp
@@ -89,6 +89,7 @@ Result<> Repository::squash(const std::string& first_commit) {
     if (!m_target_head) {
         if (auto resolve_rval = resolve_commit("HEAD", gac, m_target_head); !resolve_rval)
             return unexpected_nested(ErrorCode::GitGenericError, resolve_rval.error());
+        qDebug() << fmt::format("HEAD resolved to: {}", m_target_head);
     }
 
     auto rval = checkout_commit(first_commit);
@@ -96,6 +97,7 @@ Result<> Repository::squash(const std::string& first_commit) {
         return unexpected_nested(ErrorCode::GitGenericError, rval.error());
 
     m_first_commit = std::move(rval.value());
+    qDebug() << fmt::format("first_commit: {}", m_first_commit);
 
     const auto new_branch_name = fmt::format("git-se/{}", first_commit);
     auto rval_branch = create_branch(new_branch_name, m_first_commit);

--- a/repository.cpp
+++ b/repository.cpp
@@ -206,6 +206,9 @@ Result<SquashDiffPtr> Repository::create_squash_diff() {
 
     git_diff_foreach(diff, file_cb , binary_cb, nullptr, nullptr, &sd->m_diff_list);
 
+    if (auto rval = sd->initialize(); !rval)
+        return unexpected_nested(ErrorCode::GitSquashDiffCreateError, rval.error());
+
     return sd;
 }
 

--- a/repository.cpp
+++ b/repository.cpp
@@ -3,6 +3,7 @@
 #include <qglobal.h>
 #include <sstream>
 #include <fmt/format.h>
+#include "difflistitem.h"
 
 using namespace gitse2;
 
@@ -186,37 +187,20 @@ Result<SquashDiffPtr> Repository::create_squash_diff() {
     sd->m_diff_list.reserve(10);
 
     auto file_cb = [](const git_diff_delta *delta, float progress, void *payload) -> int {
-        SquashDiff::diff_list* lod = reinterpret_cast<SquashDiff::diff_list*>(payload);
-        SquashDiff::diff_list_item item;
+        auto& lod = *reinterpret_cast<DiffList*>(payload);
+        DiffListItemPtr item(std::make_unique<DiffListItem>());
 
-        item.original_delta = *delta;
-        if (delta->new_file.path) item.m_path_new = delta->new_file.path;
-        if (delta->old_file.path) item.m_path_old = delta->old_file.path;
+        item->add_delta(delta);
+        lod.push_back(std::move(item));
 
-        item.original_delta.new_file.path = item.m_path_new.c_str();
-        item.original_delta.old_file.path = item.m_path_old.c_str();
-
-        qDebug() << "diff, new: "<<item.m_path_new<<", old: "<<item.m_path_old;
-        lod->push_back(std::move(item));
         return GIT_OK;
     };
 
     auto binary_cb = [](const git_diff_delta *delta, const git_diff_binary *binary, void *payload) -> int {
-        auto& sd = *reinterpret_cast<SquashDiff::diff_list*>(payload);
+        auto& sd = *reinterpret_cast<DiffList*>(payload);
         if (binary->contains_data) {
             auto& item = sd.back();
-            item.original_binary_delta = *binary;
-            if (binary->new_file.datalen > 0) {
-                item.binary_data_new.resize(binary->new_file.datalen);
-                memcpy(item.binary_data_new.data(), binary->new_file.data, binary->new_file.datalen);
-            }
-            if (binary->old_file.datalen > 0) {
-                item.binary_data_old.resize(binary->old_file.datalen);
-                memcpy(item.binary_data_old.data(), binary->old_file.data, binary->old_file.datalen);
-            }
-            item.original_binary_delta.new_file.data = item.binary_data_new.data();
-            item.original_binary_delta.old_file.data = item.binary_data_old.data();
-        }
+            item->add_binary_delta(binary);}
         return GIT_OK;
     };
 

--- a/squashdiff.cpp
+++ b/squashdiff.cpp
@@ -6,6 +6,11 @@ using namespace gitse2;
 const QString& SquashDiff::diff_title() const {
     return m_diff_title;
 }
+
+const DiffTreeModel* SquashDiff::tree_model() const {
+    return m_tree_model.get();
+}
+
 Result<> SquashDiff::initialize() {
 
     // sort the diff list
@@ -13,6 +18,9 @@ Result<> SquashDiff::initialize() {
         return std::count(lhs->path().begin(), lhs->path().end(), '/') > std::count(rhs->path().begin(), rhs->path().end(), '/');
     });
 
+    auto rval = m_tree_model->create_model(m_diff_list);
+    if (!rval)
+        return unexpected_error(ErrorCode::GitSquashDiffCreateError);
 
     m_tree_model = std::move(rval.value());
     return {};

--- a/squashdiff.cpp
+++ b/squashdiff.cpp
@@ -2,3 +2,7 @@
 
 using namespace gitse2;
 
+
+const QString& SquashDiff::diff_title() const {
+    return m_diff_title;
+}

--- a/squashdiff.cpp
+++ b/squashdiff.cpp
@@ -6,3 +6,14 @@ using namespace gitse2;
 const QString& SquashDiff::diff_title() const {
     return m_diff_title;
 }
+Result<> SquashDiff::initialize() {
+
+    // sort the diff list
+    std::sort(m_diff_list.begin(), m_diff_list.end(), [](const auto& lhs, const auto& rhs) {
+        return std::count(lhs->path().begin(), lhs->path().end(), '/') > std::count(rhs->path().begin(), rhs->path().end(), '/');
+    });
+
+
+    m_tree_model = std::move(rval.value());
+    return {};
+}

--- a/squashdiff.h
+++ b/squashdiff.h
@@ -4,10 +4,9 @@
 #include <memory>
 #include <QtCore/qglobal.h>
 #include <git2.h>
-#include <string>
-#include <vector>
 #include <QString>
 #include <QObject>
+#include "difflistitem.h"
 
 namespace gitse2 {
 
@@ -16,26 +15,17 @@ namespace gitse2 {
 
         public:
 
-        struct diff_list_item {
-            git_diff_delta original_delta;
-            std::string m_path_new;
-            std::string m_path_old;
             Q_PROPERTY(QString title READ diff_title NOTIFY diff_title_changed)
 
-            git_diff_binary original_binary_delta;
-            std::vector<char> binary_data_new;
-            std::vector<char> binary_data_old;
-        };
             const QString& diff_title() const;
 
-        using diff_list = std::vector<diff_list_item>;
         signals:
             void diff_title_changed(const QString& new_title);
 
         private:
             SquashDiff() = default;
 
-            diff_list m_diff_list;
+            DiffList m_diff_list;
             QString m_diff_title {"Untitled"};
 
             friend class Repository;

--- a/squashdiff.h
+++ b/squashdiff.h
@@ -7,6 +7,7 @@
 #include <QString>
 #include <QObject>
 #include "difflistitem.h"
+#include "error-handling.h"
 
 namespace gitse2 {
 
@@ -27,6 +28,7 @@ namespace gitse2 {
 
             DiffList m_diff_list;
             QString m_diff_title {"Untitled"};
+            [[nodiscard]] Result<> initialize();
 
             friend class Repository;
     };

--- a/squashdiff.h
+++ b/squashdiff.h
@@ -8,6 +8,7 @@
 #include <QObject>
 #include "difflistitem.h"
 #include "error-handling.h"
+#include "difftreemodel.h"
 
 namespace gitse2 {
 
@@ -17,17 +18,22 @@ namespace gitse2 {
         public:
 
             Q_PROPERTY(QString title READ diff_title NOTIFY diff_title_changed)
+            Q_PROPERTY(const DiffTreeModel* tree_model READ tree_model NOTIFY tree_model_changed)
 
             const QString& diff_title() const;
+            const DiffTreeModel* tree_model() const;
 
         signals:
             void diff_title_changed(const QString& new_title);
+            void tree_model_changed(const DiffTreeModel* new_model);
 
         private:
             SquashDiff() = default;
 
             DiffList m_diff_list;
             QString m_diff_title {"Untitled"};
+            DiffTreeModelPtr m_tree_model;
+
             [[nodiscard]] Result<> initialize();
 
             friend class Repository;

--- a/squashdiff.h
+++ b/squashdiff.h
@@ -6,28 +6,37 @@
 #include <git2.h>
 #include <string>
 #include <vector>
+#include <QString>
+#include <QObject>
 
 namespace gitse2 {
 
-    class SquashDiff {
+    class SquashDiff : public QObject {
+        Q_OBJECT
+
         public:
 
         struct diff_list_item {
             git_diff_delta original_delta;
             std::string m_path_new;
             std::string m_path_old;
+            Q_PROPERTY(QString title READ diff_title NOTIFY diff_title_changed)
 
             git_diff_binary original_binary_delta;
             std::vector<char> binary_data_new;
             std::vector<char> binary_data_old;
         };
+            const QString& diff_title() const;
 
         using diff_list = std::vector<diff_list_item>;
+        signals:
+            void diff_title_changed(const QString& new_title);
 
         private:
             SquashDiff() = default;
 
             diff_list m_diff_list;
+            QString m_diff_title {"Untitled"};
 
             friend class Repository;
     };


### PR DESCRIPTION
## 1. Rename project name to get rid of hyphen

The changeset modifies the project name in the CMakeLists.txt file to remove the hyphen. It updates occurrences of `git-se2` to `gitse2` throughout the file, including changing the project name, executable name, QML module URI, target properties, include directories, and target link libraries. Additionally, it adjusts the QML module URI to `ldd.so.gitse2` and updates the bundle version and short version string properties for macOS.

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 5c2016e..3b77ce0 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@ 
 cmake_minimum_required(VERSION 3.16)
 
-project(git-se2 VERSION 0.1 LANGUAGES CXX)
+project(gitse2 VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -8,19 +8,20 @@ find_package(Qt6 6.4 REQUIRED COMPONENTS Quick QuickControls2)
 
 qt_standard_project_setup()
 
-qt_add_executable(appgit-se2
+qt_add_executable(gitse2
     main.cpp
 )
 
-qt_add_qml_module(appgit-se2
-    URI git-se2
+qt_policy(set QTP0001 NEW)
+
+qt_add_qml_module(gitse2
+    URI ldd.so.gitse2
     VERSION 1.0
-    QML_FILES
-        Main.qml
-        SOURCES error-handling.h error-handling.cpp program_options.h program_options.cpp
-        SOURCES repository.h repository.cpp git-etcetera.h
-        SOURCES squashdiff.h squashdiff.cpp
-        SOURCES squashdifflist.h squashdifflist.cpp
+    QML_FILES Main.qml
+    SOURCES error-handling.h error-handling.cpp program_options.h program_options.cpp
+    SOURCES repository.h repository.cpp git-etcetera.h
+    SOURCES squashdiff.h squashdiff.cpp
+    SOURCES squashdifflist.h squashdifflist.cpp
 )
 
 set(BUILD_TESTS OFF)
@@ -41,21 +42,21 @@ add_subdirectory(libfmt)
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.
 # If you are developing for iOS or macOS you should consider setting an
 # explicit, fixed bundle identifier manually though.
-set_target_properties(appgit-se2 PROPERTIES
-#    MACOSX_BUNDLE_GUI_IDENTIFIER com.example.appgit-se2
+set_target_properties(gitse2 PROPERTIES
+#    MACOSX_BUNDLE_GUI_IDENTIFIER gitse2
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
     MACOSX_BUNDLE TRUE
     WIN32_EXECUTABLE TRUE
 )
 
-target_include_directories(appgit-se2 PRIVATE ${PROJECT_SOURCE_DIR}/libgit2/include)
-target_link_libraries(appgit-se2
+target_include_directories(gitse2 PRIVATE ${PROJECT_SOURCE_DIR}/libgit2/include)
+target_link_libraries(gitse2
     PRIVATE Qt6::Quick Qt6::QuickControls2 libgit2package expected fmt
 )
 
 include(GNUInstallDirs)
-install(TARGETS appgit-se2
+install(TARGETS gitse2
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
```


## 2. Fix path to Main.qml

The changeset updates the path to the Main.qml file in the main.cpp file. The previous path was "qrc:/git-se2/Main.qml", and it has been changed to "qrc:/ldd/so/gitse2/Main.qml". This modification ensures that the correct Main.qml file is referenced and loaded in the application.

```diff
diff --git a/main.cpp b/main.cpp
index 8b53bcc..6c04a68 100644
--- a/main.cpp
+++ b/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
     auto *context = engine.rootContext();
     context->setContextProperty("repeater_model", &sdl);
 
-    const QUrl url(QStringLiteral("qrc:/git-se2/Main.qml"));
+    const QUrl url(QStringLiteral("qrc:/ldd/so/gitse2/Main.qml"));
     QObject::connect(
         &engine,
         &QQmlApplicationEngine::objectCreationFailed,
```


## 3. SquashDiff becomes QObject

It is also exposing a new property `title`

This changeset modifies the `SquashDiff` class in both the `squashdiff.cpp` and `squashdiff.h` files. In `squashdiff.h`, the class `SquashDiff` now inherits from `QObject` and includes the necessary headers for `QString` and `QObject`. A new property `title` is exposed using the `Q_PROPERTY` macro, with a corresponding getter function `diff_title()` and a signal `diff_title_changed`. Additionally, a member variable `m_diff_title` of type `QString` is added with a default value of "Untitled". The getter function `diff_title()` returns a constant reference to `m_diff_title`.

```diff
diff --git a/squashdiff.cpp b/squashdiff.cpp
index 1cd2164..2f60eea 100644
--- a/squashdiff.cpp
+++ b/squashdiff.cpp
@@ -2,3 +2,7 @@ 
 
 using namespace gitse2;
 
+
+const QString& SquashDiff::diff_title() const {
+    return m_diff_title;
+}
```
```diff
diff --git a/squashdiff.h b/squashdiff.h
index 898e22f..4780ade 100644
--- a/squashdiff.h
+++ b/squashdiff.h
@@ -6,28 +6,37 @@ 
 #include <git2.h>
 #include <string>
 #include <vector>
+#include <QString>
+#include <QObject>
 
 namespace gitse2 {
 
-    class SquashDiff {
+    class SquashDiff : public QObject {
+        Q_OBJECT
+
         public:
 
         struct diff_list_item {
             git_diff_delta original_delta;
             std::string m_path_new;
             std::string m_path_old;
+            Q_PROPERTY(QString title READ diff_title NOTIFY diff_title_changed)
 
             git_diff_binary original_binary_delta;
             std::vector<char> binary_data_new;
             std::vector<char> binary_data_old;
         };
+            const QString& diff_title() const;
 
         using diff_list = std::vector<diff_list_item>;
+        signals:
+            void diff_title_changed(const QString& new_title);
 
         private:
             SquashDiff() = default;
 
             diff_list m_diff_list;
+            QString m_diff_title {"Untitled"};
 
             friend class Repository;
     };
```


## 4. DiffList is moved to separate file and renamed from `diff_list_item`

The changeset includes adding two new files, `difflistitem.cpp` and `difflistitem.h`. In the existing `squashdiff.h` file, the `diff_list_item` struct is removed and replaced with `DiffList` class. The `DiffList` class is now included in the file using `#include "difflistitem.h"`. The `diff_list` type alias is removed and replaced with `DiffList`.

```diff
diff --git a/squashdiff.h b/squashdiff.h
index 6a8e955..4780ade 100644
--- a/squashdiff.h
+++ b/squashdiff.h
@@ -4,10 +4,9 @@ 
 #include <memory>
 #include <QtCore/qglobal.h>
 #include <git2.h>
-#include <string>
-#include <vector>
 #include <QString>
 #include <QObject>
+#include "difflistitem.h"
 
 namespace gitse2 {
 
@@ -16,27 +15,18 @@ namespace gitse2 {
 
         public:
 
-        struct diff_list_item {
-            git_diff_delta original_delta;
-            std::string m_path_new;
-            std::string m_path_old;
             Q_PROPERTY(QString title READ diff_title NOTIFY diff_title_changed)
 
-            git_diff_binary original_binary_delta;
-            std::vector<char> binary_data_new;
-            std::vector<char> binary_data_old;
-        };
             const QString& diff_title() const;
 
-        using diff_list = std::vector<diff_list_item>;
         signals:
             void diff_title_changed(const QString& new_title);
 
         private:
             SquashDiff() = default;
 
-            diff_list m_diff_list;
+            DiffList m_diff_list;
             QString m_diff_title {"Untitled"};
 
             friend class Repository;
     };
```

### File changes
```
[+] difflistitem.cpp
[+] difflistitem.h

```


## 5. Add debug messages for head and first commit

The changeset adds debug messages to the `Repository::squash` function in the `repository.cpp` file. Specifically, it includes debug messages to print out the resolved `HEAD` commit and the `first_commit` commit. This can be helpful for debugging and understanding the flow of the code when squashing commits in the repository.

```diff
diff --git a/repository.cpp b/repository.cpp
index 965bf62..2e214ea 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -89,6 +89,7 @@ Result<> Repository::squash(const std::string& first_commit) {
     if (!m_target_head) {
         if (auto resolve_rval = resolve_commit("HEAD", gac, m_target_head); !resolve_rval)
             return unexpected_nested(ErrorCode::GitGenericError, resolve_rval.error());
+        qDebug() << fmt::format("HEAD resolved to: {}", m_target_head);
     }
 
     auto rval = checkout_commit(first_commit);
@@ -96,6 +97,7 @@ Result<> Repository::squash(const std::string& first_commit) {
         return unexpected_nested(ErrorCode::GitGenericError, rval.error());
 
     m_first_commit = std::move(rval.value());
+    qDebug() << fmt::format("first_commit: {}", m_first_commit);
 
     const auto new_branch_name = fmt::format("git-se/{}", first_commit);
     auto rval_branch = create_branch(new_branch_name, m_first_commit);
```


## 6. Repository is now using new `DiffListItem` class

The changeset introduces the usage of the new `DiffListItem` class in the repository. It includes modifications in the `repository.cpp` file where the `SquashDiff::diff_list` is replaced with `DiffList`, and `SquashDiff::diff_list_item` is replaced with `DiffListItemPtr`. The `add_delta` and `add_binary_delta` methods are used to add delta and binary delta information to the `DiffListItem` objects. Additionally, some unnecessary code related to paths and binary data handling has been removed.

```diff
diff --git a/repository.cpp b/repository.cpp
index fca60a4..2e214ea 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -3,6 +3,7 @@ 
 #include <qglobal.h>
 #include <sstream>
 #include <fmt/format.h>
+#include "difflistitem.h"
 
 using namespace gitse2;
 
@@ -186,42 +187,25 @@ Result<SquashDiffPtr> Repository::create_squash_diff() {
     sd->m_diff_list.reserve(10);
 
     auto file_cb = [](const git_diff_delta *delta, float progress, void *payload) -> int {
-        SquashDiff::diff_list* lod = reinterpret_cast<SquashDiff::diff_list*>(payload);
-        SquashDiff::diff_list_item item;
+        auto& lod = *reinterpret_cast<DiffList*>(payload);
+        DiffListItemPtr item(std::make_unique<DiffListItem>());
 
-        item.original_delta = *delta;
-        if (delta->new_file.path) item.m_path_new = delta->new_file.path;
-        if (delta->old_file.path) item.m_path_old = delta->old_file.path;
+        item->add_delta(delta);
+        lod.push_back(std::move(item));
 
-        item.original_delta.new_file.path = item.m_path_new.c_str();
-        item.original_delta.old_file.path = item.m_path_old.c_str();
-
-        qDebug() << "diff, new: "<<item.m_path_new<<", old: "<<item.m_path_old;
-        lod->push_back(std::move(item));
         return GIT_OK;
     };
 
     auto binary_cb = [](const git_diff_delta *delta, const git_diff_binary *binary, void *payload) -> int {
-        auto& sd = *reinterpret_cast<SquashDiff::diff_list*>(payload);
+        auto& sd = *reinterpret_cast<DiffList*>(payload);
         if (binary->contains_data) {
             auto& item = sd.back();
-            item.original_binary_delta = *binary;
-            if (binary->new_file.datalen > 0) {
-                item.binary_data_new.resize(binary->new_file.datalen);
-                memcpy(item.binary_data_new.data(), binary->new_file.data, binary->new_file.datalen);
-            }
-            if (binary->old_file.datalen > 0) {
-                item.binary_data_old.resize(binary->old_file.datalen);
-                memcpy(item.binary_data_old.data(), binary->old_file.data, binary->old_file.datalen);
-            }
-            item.original_binary_delta.new_file.data = item.binary_data_new.data();
-            item.original_binary_delta.old_file.data = item.binary_data_old.data();
-        }
+            item->add_binary_delta(binary);}
         return GIT_OK;
     };
 
     git_diff_foreach(diff, file_cb , binary_cb, nullptr, nullptr, &sd->m_diff_list);
 
     return sd;
 }
```


## 7. Repository initializes SquashDiff

Repository is a factory for SquashDiff. It is decided that it will call `initialize` method as a constructor

The changeset includes modifications in three files. 

In `repository.cpp`, a new condition is added to call the `initialize` method of `SquashDiff` before returning the `SquashDiffPtr` object. If the initialization fails, an error is returned.

In `squashdiff.cpp`, the `initialize` method is defined. Inside this method, the `m_diff_list` is sorted based on the count of slashes in the path of each element. After sorting, the `m_tree_model` is assigned a value, and an empty `Result` is returned.

In `squashdiff.h`, the `initialize` method is declared as `[[nodiscard]]`, indicating that the method should not be ignored by the caller. Additionally, an include statement for `error-handling.h` is added to import necessary error handling functionalities.

```diff
diff --git a/repository.cpp b/repository.cpp
index a9662ee..2e214ea 100644
--- a/repository.cpp
+++ b/repository.cpp
@@ -206,6 +206,9 @@ Result<SquashDiffPtr> Repository::create_squash_diff() {
 
     git_diff_foreach(diff, file_cb , binary_cb, nullptr, nullptr, &sd->m_diff_list);
 
+    if (auto rval = sd->initialize(); !rval)
+        return unexpected_nested(ErrorCode::GitSquashDiffCreateError, rval.error());
+
     return sd;
 }
```
```diff
diff --git a/squashdiff.cpp b/squashdiff.cpp
index 7e87648..2f60eea 100644
--- a/squashdiff.cpp
+++ b/squashdiff.cpp
@@ -6,3 +6,14 @@ using namespace gitse2;
 const QString& SquashDiff::diff_title() const {
     return m_diff_title;
 }
+Result<> SquashDiff::initialize() {
+
+    // sort the diff list
+    std::sort(m_diff_list.begin(), m_diff_list.end(), [](const auto& lhs, const auto& rhs) {
+        return std::count(lhs->path().begin(), lhs->path().end(), '/') > std::count(rhs->path().begin(), rhs->path().end(), '/');
+    });
+
+
+    m_tree_model = std::move(rval.value());
+    return {};
+}
```
```diff
diff --git a/squashdiff.h b/squashdiff.h
index 42583b0..4780ade 100644
--- a/squashdiff.h
+++ b/squashdiff.h
@@ -7,6 +7,7 @@ 
 #include <QString>
 #include <QObject>
 #include "difflistitem.h"
+#include "error-handling.h"
 
 namespace gitse2 {
 
@@ -27,6 +28,7 @@ namespace gitse2 {
 
             DiffList m_diff_list;
             QString m_diff_title {"Untitled"};
+            [[nodiscard]] Result<> initialize();
 
             friend class Repository;
     };
```


## 8. Introduce `DiffTreeItem` class

`DiffTreeItem` class is a tree item for the Qt treeview qml

This changeset introduces a new class called `DiffTreeItem`. This class is designed to be used as a tree item in the Qt treeview QML. The changeset includes the addition of `difftreeitem.cpp` and `difftreeitem.h` files to the project.


### File changes
```
[+] difftreeitem.cpp
[+] difftreeitem.h

```


## 9. Introduce `DiffTreeModel` class

`DiffTreeModel` class is a tree model for Qt treeview

This changeset introduces a new class called `DiffTreeModel`. This class serves as a tree model specifically designed for Qt treeview. The changeset includes the addition of `difftreemodel.cpp` and `difftreemodel.h` files to the project.


### File changes
```
[+] difftreemodel.cpp
[+] difftreemodel.h

```


## 10. Connect tree model to QML

This changeset connects the tree model to QML by adding a new method `tree_model()` in the `SquashDiff` class in `squashdiff.cpp` file. This method returns the `m_tree_model` object. Additionally, a new signal `tree_model_changed` is added to the class declaration in the `squashdiff.h` file to notify when the tree model changes. The `m_tree_model` member variable is also added to the `SquashDiff` class. The `initialize()` method now creates the model using the `m_tree_model` and returns an error if the model creation fails.

```diff
diff --git a/squashdiff.cpp b/squashdiff.cpp
index 284e488..2f60eea 100644
--- a/squashdiff.cpp
+++ b/squashdiff.cpp
@@ -6,6 +6,11 @@ using namespace gitse2;
 const QString& SquashDiff::diff_title() const {
     return m_diff_title;
 }
+
+const DiffTreeModel* SquashDiff::tree_model() const {
+    return m_tree_model.get();
+}
+
 Result<> SquashDiff::initialize() {
 
     // sort the diff list
@@ -13,6 +18,9 @@ Result<> SquashDiff::initialize() {
         return std::count(lhs->path().begin(), lhs->path().end(), '/') > std::count(rhs->path().begin(), rhs->path().end(), '/');
     });
 
+    auto rval = m_tree_model->create_model(m_diff_list);
+    if (!rval)
+        return unexpected_error(ErrorCode::GitSquashDiffCreateError);
 
     m_tree_model = std::move(rval.value());
     return {};
```
```diff
diff --git a/squashdiff.h b/squashdiff.h
index 6259afe..4780ade 100644
--- a/squashdiff.h
+++ b/squashdiff.h
@@ -8,6 +8,7 @@ 
 #include <QObject>
 #include "difflistitem.h"
 #include "error-handling.h"
+#include "difftreemodel.h"
 
 namespace gitse2 {
 
@@ -17,17 +18,22 @@ namespace gitse2 {
         public:
 
             Q_PROPERTY(QString title READ diff_title NOTIFY diff_title_changed)
+            Q_PROPERTY(const DiffTreeModel* tree_model READ tree_model NOTIFY tree_model_changed)
 
             const QString& diff_title() const;
+            const DiffTreeModel* tree_model() const;
 
         signals:
             void diff_title_changed(const QString& new_title);
+            void tree_model_changed(const DiffTreeModel* new_model);
 
         private:
             SquashDiff() = default;
 
             DiffList m_diff_list;
             QString m_diff_title {"Untitled"};
+            DiffTreeModelPtr m_tree_model;
+
             [[nodiscard]] Result<> initialize();
 
             friend class Repository;
```


## 11. QML modifications

This changeset adds repeaters and fixes QML styles

This changeset includes modifications to the QML code. It adds repeaters and addresses issues with QML styles. The file "Main.qml" has been added with these changes.


### File changes
```
[+] Main.qml

```


## 12. Add tree item and tree model to CMakeLists

The changeset adds `difftreeitem.h`, `difftreeitem.cpp`, `difflistitem.h`, `difflistitem.cpp`, `difftreemodel.h`, and `difftreemodel.cpp` to the `qt_add_qml_module` in the `CMakeLists.txt` file. This means that tree item and tree model functionality is being included in the project build configuration.

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index c55d684..3b77ce0 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ qt_add_qml_module(gitse2
     SOURCES repository.h repository.cpp git-etcetera.h
     SOURCES squashdiff.h squashdiff.cpp
     SOURCES squashdifflist.h squashdifflist.cpp
+    SOURCES difftreeitem.h difftreeitem.cpp
+    SOURCES difflistitem.h difflistitem.cpp
+    SOURCES difftreemodel.h difftreemodel.cpp
 )
 
 set(BUILD_TESTS OFF)
```

